### PR TITLE
feat: Phase 2 — Git intelligence signals

### DIFF
--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -5,6 +5,7 @@ import { parseFile } from '../../core/ast/parseFile.ts'
 import { buildDependencyGraph } from '../../core/graph/buildDependencyGraph.ts'
 import { buildReverseDependencyGraph } from '../../core/graph/buildReverseDependencyGraph.ts'
 import { findRelatedTests } from '../../core/tests/findRelatedTests.ts'
+import { getGitSignals } from '../../core/git/getGitSignals.ts'
 import { buildBasicNote } from '../../core/output/buildBasicNote.ts'
 import { writeJsonNote } from '../../core/output/writeJsonNote.ts'
 import { logger } from '../../core/utils/logger.ts'
@@ -28,12 +29,16 @@ export async function runGenerate(args: { root?: string }): Promise<void> {
   const depGraph = buildDependencyGraph(analyses, root)
   const revGraph = buildReverseDependencyGraph(depGraph)
 
-  // 4. Generate and write notes
+  // 4. Git intelligence
+  logger.info('Extracting git signals...')
+
+  // 5. Generate and write notes
   logger.info('Writing notes...')
   let written = 0
 
   for (const analysis of analyses) {
     const relatedTests = findRelatedTests(analysis.filePath, files)
+    const gitSignals = getGitSignals(analysis.filePath, root)
 
     const note = buildBasicNote(
       analysis,
@@ -46,6 +51,7 @@ export async function runGenerate(args: { root?: string }): Promise<void> {
         filePath: analysis.filePath,
         relatedTests,
       },
+      gitSignals,
     )
 
     await writeJsonNote(note, root, config.output)

--- a/src/core/git/getCoChangedFiles.ts
+++ b/src/core/git/getCoChangedFiles.ts
@@ -1,0 +1,56 @@
+import path from 'node:path'
+
+export type CoChangedFile = { path: string; count: number }
+
+const TOP_N = 10
+
+export function getCoChangedFiles(filePath: string, root: string): CoChangedFile[] {
+  try {
+    const relPath = path.relative(root, filePath)
+
+    // Get all commit hashes that touched this file
+    const hashResult = Bun.spawnSync(
+      ['git', 'log', '--follow', '--format=%H', '--', relPath],
+      { cwd: root },
+    )
+
+    if (hashResult.exitCode !== 0) return []
+
+    const hashes = hashResult.stdout
+      .toString()
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+
+    if (hashes.length === 0) return []
+
+    // For each commit, get the list of files changed
+    const frequency = new Map<string, number>()
+
+    for (const hash of hashes) {
+      const filesResult = Bun.spawnSync(
+        ['git', 'diff-tree', '--no-commit-id', '-r', '--name-only', hash],
+        { cwd: root },
+      )
+
+      if (filesResult.exitCode !== 0) continue
+
+      const changedFiles = filesResult.stdout
+        .toString()
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((f) => f && f !== relPath)
+
+      for (const f of changedFiles) {
+        frequency.set(f, (frequency.get(f) ?? 0) + 1)
+      }
+    }
+
+    return [...frequency.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, TOP_N)
+      .map(([p, count]) => ({ path: path.resolve(root, p), count }))
+  } catch {
+    return []
+  }
+}

--- a/src/core/git/getFileHistory.ts
+++ b/src/core/git/getFileHistory.ts
@@ -1,0 +1,52 @@
+import path from 'node:path'
+
+export type FileHistory = {
+  churnScore: number
+  recentCommitMessages: string[]
+  authorCount: number
+}
+
+const RECENT_COMMITS_LIMIT = 10
+
+export function getFileHistory(filePath: string, root: string): FileHistory {
+  try {
+    const relPath = path.relative(root, filePath)
+
+    const logResult = Bun.spawnSync(
+      ['git', 'log', '--follow', `--format=%s`, '--', relPath],
+      { cwd: root },
+    )
+
+    if (logResult.exitCode !== 0) return empty()
+
+    const messages = logResult.stdout
+      .toString()
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+
+    const shortlogResult = Bun.spawnSync(
+      ['git', 'shortlog', '-sn', '--follow', '--', relPath],
+      { cwd: root },
+    )
+
+    const authorCount = shortlogResult.exitCode === 0
+      ? shortlogResult.stdout
+          .toString()
+          .split('\n')
+          .filter(Boolean).length
+      : 0
+
+    return {
+      churnScore: messages.length,
+      recentCommitMessages: messages.slice(0, RECENT_COMMITS_LIMIT),
+      authorCount,
+    }
+  } catch {
+    return empty()
+  }
+}
+
+function empty(): FileHistory {
+  return { churnScore: 0, recentCommitMessages: [], authorCount: 0 }
+}

--- a/src/core/git/getGitSignals.ts
+++ b/src/core/git/getGitSignals.ts
@@ -1,0 +1,39 @@
+import type { GitSignals } from '../types/file-analysis.ts'
+import { getFileHistory } from './getFileHistory.ts'
+import { getCoChangedFiles } from './getCoChangedFiles.ts'
+
+export function getGitSignals(filePath: string, root: string): GitSignals {
+  if (!isGitRepo(root)) {
+    return empty(filePath)
+  }
+
+  const history = getFileHistory(filePath, root)
+  const coChangedFiles = getCoChangedFiles(filePath, root)
+
+  return {
+    filePath,
+    churnScore: history.churnScore,
+    recentCommitMessages: history.recentCommitMessages,
+    coChangedFiles,
+    authorCount: history.authorCount,
+  }
+}
+
+function isGitRepo(root: string): boolean {
+  try {
+    const result = Bun.spawnSync(['git', 'rev-parse', '--git-dir'], { cwd: root })
+    return result.exitCode === 0
+  } catch {
+    return false
+  }
+}
+
+function empty(filePath: string): GitSignals {
+  return {
+    filePath,
+    churnScore: 0,
+    recentCommitMessages: [],
+    coChangedFiles: [],
+    authorCount: 0,
+  }
+}

--- a/src/core/output/buildBasicNote.ts
+++ b/src/core/output/buildBasicNote.ts
@@ -1,10 +1,13 @@
-import type { StaticFileAnalysis, GraphSignals, TestSignals } from '../types/file-analysis.ts'
+import type { StaticFileAnalysis, GraphSignals, TestSignals, GitSignals } from '../types/file-analysis.ts'
 import type { AiFileNote, EvidenceItem, StructuredListField } from '../types/ai-note.ts'
+
+const RISKY_COMMIT_KEYWORDS = ['hotfix', 'rollback', 'workaround', 'revert', 'hack', 'fix', 'breaking']
 
 export function buildBasicNote(
   analysis: StaticFileAnalysis,
   graph: GraphSignals,
   tests: TestSignals,
+  git: GitSignals,
 ): AiFileNote {
   const purposeObserved: string[] = []
   const purposeEvidence: EvidenceItem[] = []
@@ -37,6 +40,7 @@ export function buildBasicNote(
     ...graph.reverseDependencies.slice(0, 5).map((r) => ({ type: 'graph' as const, detail: `Reverse dep: ${r}` })),
   ]
 
+  // knownPitfalls: comments + risky commit messages + high-frequency co-changes
   const pitfallsObserved: string[] = []
   const pitfallsEvidence: EvidenceItem[] = []
 
@@ -53,16 +57,37 @@ export function buildBasicNote(
     pitfallsEvidence.push({ type: 'comment', detail: hack })
   }
 
+  for (const msg of git.recentCommitMessages) {
+    const lower = msg.toLowerCase()
+    if (RISKY_COMMIT_KEYWORDS.some((kw) => lower.includes(kw))) {
+      pitfallsObserved.push(`Commit: "${msg}"`)
+      pitfallsEvidence.push({ type: 'git', detail: msg })
+    }
+  }
+
+  const highFreqCoChanged = git.coChangedFiles.filter((f) => f.count >= 2)
+  if (highFreqCoChanged.length > 0) {
+    pitfallsObserved.push(
+      `Co-changes frequently with: ${highFreqCoChanged.map((f) => f.path).join(', ')}`,
+    )
+    for (const f of highFreqCoChanged) {
+      pitfallsEvidence.push({ type: 'git', detail: `Co-changed ${f.count}x with ${f.path}` })
+    }
+  }
+
+  // impactValidation: consumers + tests + co-changed files
   const impactObserved: string[] = [
     ...graph.reverseDependencies,
     ...tests.relatedTests,
+    ...git.coChangedFiles.map((f) => f.path),
   ]
   const impactEvidence: EvidenceItem[] = [
     ...graph.reverseDependencies.map((r) => ({ type: 'graph' as const, detail: `Consumer: ${r}` })),
     ...tests.relatedTests.map((t) => ({ type: 'test' as const, detail: `Related test: ${t}` })),
+    ...git.coChangedFiles.map((f) => ({ type: 'git' as const, detail: `Co-changed ${f.count}x: ${f.path}` })),
   ]
 
-  const criticalityScore = computeCriticality(analysis, graph, tests)
+  const criticalityScore = computeCriticality(analysis, graph, tests, git)
 
   const emptyField = (): StructuredListField => ({
     observed: [],
@@ -94,7 +119,7 @@ export function buildBasicNote(
       evidence: pitfallsEvidence,
     },
     impactValidation: {
-      observed: impactObserved,
+      observed: [...new Set(impactObserved)],
       inferred: [],
       confidence: impactObserved.length > 0 ? 0.8 : 0.1,
       evidence: impactEvidence,
@@ -109,6 +134,7 @@ function computeCriticality(
   analysis: StaticFileAnalysis,
   graph: GraphSignals,
   tests: TestSignals,
+  git: GitSignals,
 ): number {
   let score = 0
 
@@ -116,7 +142,7 @@ function computeCriticality(
   score += Math.min(graph.reverseDependencies.length * 0.1, 0.4)
 
   // Hooks are generally critical
-  if (analysis.hooks.length > 0) score += 0.2
+  if (analysis.hooks.length > 0) score += 0.15
 
   // External deps (API, env) increase criticality
   if (analysis.externalImports.length > 0) score += 0.1
@@ -124,11 +150,17 @@ function computeCriticality(
 
   // Known pitfalls increase criticality
   if (analysis.comments.todo.length + analysis.comments.fixme.length + analysis.comments.hack.length > 0) {
-    score += 0.1
+    score += 0.05
   }
 
   // No tests = higher risk
   if (tests.relatedTests.length === 0) score += 0.1
+
+  // High churn = more critical (capped at 0.15)
+  score += Math.min(git.churnScore * 0.01, 0.15)
+
+  // Multiple authors = higher coordination risk
+  if (git.authorCount > 3) score += 0.05
 
   return Math.min(parseFloat(score.toFixed(2)), 1)
 }

--- a/src/core/types/file-analysis.ts
+++ b/src/core/types/file-analysis.ts
@@ -26,3 +26,11 @@ export type TestSignals = {
   filePath: string
   relatedTests: string[]
 }
+
+export type GitSignals = {
+  filePath: string
+  churnScore: number
+  recentCommitMessages: string[]
+  coChangedFiles: Array<{ path: string; count: number }>
+  authorCount: number
+}

--- a/tests/git/getCoChangedFiles.test.ts
+++ b/tests/git/getCoChangedFiles.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'bun:test'
+import path from 'node:path'
+import { getCoChangedFiles } from '../../src/core/git/getCoChangedFiles.ts'
+
+const repoRoot = path.resolve(import.meta.dir, '../..')
+
+describe('getCoChangedFiles', () => {
+  it('returns empty array for a non-existent file', () => {
+    const result = getCoChangedFiles('/tmp/ghost.ts', repoRoot)
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns co-changed files for a tracked file', () => {
+    const filePath = path.resolve(repoRoot, 'src/core/types/ai-note.ts')
+    const result = getCoChangedFiles(filePath, repoRoot)
+    expect(Array.isArray(result)).toBe(true)
+    for (const entry of result) {
+      expect(typeof entry.path).toBe('string')
+      expect(entry.count).toBeGreaterThan(0)
+    }
+  })
+
+  it('results are sorted by count descending', () => {
+    const filePath = path.resolve(repoRoot, 'src/core/types/ai-note.ts')
+    const result = getCoChangedFiles(filePath, repoRoot)
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i - 1].count).toBeGreaterThanOrEqual(result[i].count)
+    }
+  })
+})

--- a/tests/git/getFileHistory.test.ts
+++ b/tests/git/getFileHistory.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'bun:test'
+import path from 'node:path'
+import { getFileHistory } from '../../src/core/git/getFileHistory.ts'
+
+const repoRoot = path.resolve(import.meta.dir, '../..')
+
+describe('getFileHistory', () => {
+  it('returns empty history for a non-existent file', () => {
+    const result = getFileHistory('/tmp/ghost.ts', repoRoot)
+    expect(result.churnScore).toBe(0)
+    expect(result.recentCommitMessages).toHaveLength(0)
+    expect(result.authorCount).toBe(0)
+  })
+
+  it('returns history for a tracked file', () => {
+    const filePath = path.resolve(repoRoot, 'src/core/types/ai-note.ts')
+    const result = getFileHistory(filePath, repoRoot)
+    expect(result.churnScore).toBeGreaterThanOrEqual(0)
+    expect(Array.isArray(result.recentCommitMessages)).toBe(true)
+    expect(result.recentCommitMessages.length).toBeLessThanOrEqual(10)
+  })
+})

--- a/tests/git/getGitSignals.test.ts
+++ b/tests/git/getGitSignals.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'bun:test'
+import path from 'node:path'
+import { getGitSignals } from '../../src/core/git/getGitSignals.ts'
+
+const repoRoot = path.resolve(import.meta.dir, '../..')
+const sampleFile = path.resolve(repoRoot, 'src/core/output/buildBasicNote.ts')
+
+describe('getGitSignals', () => {
+  it('returns empty signals for a non-git directory', () => {
+    const result = getGitSignals('/tmp/not-a-git-repo/file.ts', '/tmp/not-a-git-repo')
+    expect(result.churnScore).toBe(0)
+    expect(result.recentCommitMessages).toHaveLength(0)
+    expect(result.coChangedFiles).toHaveLength(0)
+    expect(result.authorCount).toBe(0)
+  })
+
+  it('returns GitSignals shape for a real file in the repo', () => {
+    const result = getGitSignals(sampleFile, repoRoot)
+    expect(typeof result.churnScore).toBe('number')
+    expect(Array.isArray(result.recentCommitMessages)).toBe(true)
+    expect(Array.isArray(result.coChangedFiles)).toBe(true)
+    expect(typeof result.authorCount).toBe('number')
+    expect(result.filePath).toBe(sampleFile)
+  })
+
+  it('coChangedFiles entries have path and count', () => {
+    const result = getGitSignals(sampleFile, repoRoot)
+    for (const entry of result.coChangedFiles) {
+      expect(typeof entry.path).toBe('string')
+      expect(typeof entry.count).toBe('number')
+      expect(entry.count).toBeGreaterThan(0)
+    }
+  })
+})

--- a/tests/output/buildBasicNote.test.ts
+++ b/tests/output/buildBasicNote.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test'
 import { buildBasicNote } from '../../src/core/output/buildBasicNote.ts'
-import type { StaticFileAnalysis, GraphSignals, TestSignals } from '../../src/core/types/file-analysis.ts'
+import type { StaticFileAnalysis, GraphSignals, TestSignals, GitSignals } from '../../src/core/types/file-analysis.ts'
 
 function makeAnalysis(overrides: Partial<StaticFileAnalysis> = {}): StaticFileAnalysis {
   return {
@@ -30,41 +30,83 @@ const tests: TestSignals = {
   relatedTests: ['/project/src/useSearch.spec.ts'],
 }
 
+const emptyGit: GitSignals = {
+  filePath: '/project/src/useSearch.ts',
+  churnScore: 0,
+  recentCommitMessages: [],
+  coChangedFiles: [],
+  authorCount: 0,
+}
+
 describe('buildBasicNote', () => {
   it('sets model to "static"', () => {
-    const note = buildBasicNote(makeAnalysis(), graph, tests)
+    const note = buildBasicNote(makeAnalysis(), graph, tests, emptyGit)
     expect(note.model).toBe('static')
   })
 
   it('includes hooks in purpose.observed', () => {
-    const note = buildBasicNote(makeAnalysis(), graph, tests)
+    const note = buildBasicNote(makeAnalysis(), graph, tests, emptyGit)
     expect(note.purpose.observed.some((o) => o.includes('useSearch'))).toBe(true)
   })
 
   it('includes reverse deps in sensitiveDependencies.observed', () => {
-    const note = buildBasicNote(makeAnalysis(), graph, tests)
+    const note = buildBasicNote(makeAnalysis(), graph, tests, emptyGit)
     expect(note.sensitiveDependencies.observed).toContain('/project/src/SearchScreen.tsx')
   })
 
   it('includes related tests in impactValidation.observed', () => {
-    const note = buildBasicNote(makeAnalysis(), graph, tests)
+    const note = buildBasicNote(makeAnalysis(), graph, tests, emptyGit)
     expect(note.impactValidation.observed).toContain('/project/src/useSearch.spec.ts')
   })
 
   it('captures TODO comments in knownPitfalls', () => {
     const analysis = makeAnalysis({ comments: { todo: ['TODO: fix this'], fixme: [], hack: [] } })
-    const note = buildBasicNote(analysis, graph, tests)
+    const note = buildBasicNote(analysis, graph, tests, emptyGit)
     expect(note.knownPitfalls.observed).toContain('TODO: fix this')
   })
 
+  it('adds risky commit messages to knownPitfalls', () => {
+    const git: GitSignals = {
+      ...emptyGit,
+      recentCommitMessages: ['hotfix: revert search pagination', 'chore: update deps'],
+    }
+    const note = buildBasicNote(makeAnalysis(), graph, tests, git)
+    expect(note.knownPitfalls.observed.some((o) => o.includes('hotfix'))).toBe(true)
+    expect(note.knownPitfalls.evidence.some((e) => e.type === 'git')).toBe(true)
+  })
+
+  it('adds co-changed files to impactValidation.observed', () => {
+    const git: GitSignals = {
+      ...emptyGit,
+      coChangedFiles: [{ path: '/project/src/SearchScreen.tsx', count: 5 }],
+    }
+    const note = buildBasicNote(makeAnalysis(), graph, tests, git)
+    expect(note.impactValidation.observed).toContain('/project/src/SearchScreen.tsx')
+  })
+
+  it('high-frequency co-changes appear in knownPitfalls', () => {
+    const git: GitSignals = {
+      ...emptyGit,
+      coChangedFiles: [{ path: '/project/src/SearchScreen.tsx', count: 3 }],
+    }
+    const note = buildBasicNote(makeAnalysis(), graph, tests, git)
+    expect(note.knownPitfalls.observed.some((o) => o.includes('Co-changes frequently'))).toBe(true)
+  })
+
+  it('criticalityScore increases with churn', () => {
+    const lowChurn = buildBasicNote(makeAnalysis(), graph, tests, emptyGit)
+    const highChurn = buildBasicNote(makeAnalysis(), graph, tests, { ...emptyGit, churnScore: 20 })
+    expect(highChurn.criticalityScore).toBeGreaterThan(lowChurn.criticalityScore)
+  })
+
   it('criticalityScore is between 0 and 1', () => {
-    const note = buildBasicNote(makeAnalysis(), graph, tests)
+    const note = buildBasicNote(makeAnalysis(), graph, tests, emptyGit)
     expect(note.criticalityScore).toBeGreaterThanOrEqual(0)
     expect(note.criticalityScore).toBeLessThanOrEqual(1)
   })
 
   it('has a valid ISO generatedAt date', () => {
-    const note = buildBasicNote(makeAnalysis(), graph, tests)
+    const note = buildBasicNote(makeAnalysis(), graph, tests, emptyGit)
     expect(() => new Date(note.generatedAt).toISOString()).not.toThrow()
   })
 })


### PR DESCRIPTION
## Contexto

Fase 2 do braito. Enriquece as notas com sinais do histórico Git, melhorando a qualidade de `knownPitfalls`, `impactValidation` e `criticalityScore` — ainda sem LLM.

---

## O que foi implementado

### Novo tipo: `GitSignals`
**`src/core/types/file-analysis.ts`**

```ts
type GitSignals = {
  filePath: string
  churnScore: number                              // total de commits que tocaram o arquivo
  recentCommitMessages: string[]                  // últimas 10 mensagens
  coChangedFiles: Array<{ path: string; count: number }>  // arquivos que mudam junto
  authorCount: number                             // número de autores distintos
}
```

---

### Módulo `src/core/git/`

#### `getFileHistory.ts`
Extrai via `git log --follow` e `git shortlog -sn`:
- `churnScore` — número total de commits que tocaram o arquivo
- `recentCommitMessages` — últimas 10 mensagens de commit
- `authorCount` — número de autores distintos

#### `getCoChangedFiles.ts`
Para cada commit que tocou o arquivo, coleta os demais arquivos modificados no mesmo commit e rankeia por frequência. Retorna top 10.

#### `getGitSignals.ts`
Orquestra os dois módulos. Fallback silencioso quando o diretório não é um repositório Git.

---

### `buildBasicNote.ts` — novos sinais incorporados

| Campo | O que mudou |
|---|---|
| `knownPitfalls` | Mensagens de commit com keywords de risco (`hotfix`, `rollback`, `revert`, `hack`, `fix`, `workaround`) adicionadas com `evidence.type: "git"` |
| `knownPitfalls` | Co-changes com frequência ≥ 2 adicionados como sinal de acoplamento |
| `impactValidation` | Co-changed files adicionados ao `observed` com evidência git |
| `criticalityScore` | Ponderado por `churnScore` (até +0.15) e `authorCount > 3` (+0.05) |

---

### `generate.ts` — pipeline atualizado

```
scan → parse → graph → git signals → build notes → write
```

---

### Testes — 3 novas suítes + atualização

| Arquivo | Cobertura |
|---|---|
| `tests/git/getFileHistory.test.ts` | Histórico de arquivo rastreado e fallback para arquivo inexistente |
| `tests/git/getCoChangedFiles.test.ts` | Co-changes, ordenação por frequência, fallback |
| `tests/git/getGitSignals.test.ts` | Shape do retorno, fallback em diretório sem git |
| `tests/output/buildBasicNote.test.ts` | Novos casos: commits de risco, co-change em pitfalls, churn no score |

---

## Como verificar

```bash
bun install
bun test
bun src/cli/index.ts generate --root ./
```

Abrir `.ai-notes/src/core/output/buildBasicNote.ts.json` e verificar:
- `knownPitfalls.evidence` com `type: "git"`
- `impactValidation.observed` com co-changed files
- `criticalityScore` refletindo churn

---

## O que fica para as próximas fases

- LLM synthesizer (`inferred`, `invariants`, `importantDecisions`) — Fase 3
- Markdown sidecar — Fase 3
- Cache por hash, watch mode, CI — Fase 4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)