### PR TITLE
feat: Phase 3 — LLM synthesizer + Markdown sidecar

### DIFF
--- a/ai-notes.config.ts
+++ b/ai-notes.config.ts
@@ -11,6 +11,22 @@ const config: Partial<AiNotesConfig> = {
     '**/*.d.ts',
   ],
   output: '.ai-notes',
+
+  // LLM synthesis — uncomment to enable
+  // llm: {
+  //   provider: 'ollama',
+  //   model: 'llama3',
+  //   llmThreshold: 0.4,   // only synthesize files with criticalityScore >= this
+  //   temperature: 0.2,
+  // },
+
+  // For Anthropic:
+  // llm: {
+  //   provider: 'anthropic',
+  //   model: 'claude-sonnet-4-6',
+  //   // apiKey: 'sk-ant-...',  // or set ANTHROPIC_API_KEY env var
+  //   llmThreshold: 0.4,
+  // },
 }
 
 export default config

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
     "test": "bun test"
   },
   "dependencies": {
-    "ts-morph": "^25.0.0"
+    "ts-morph": "^25.0.0",
+    "zod": "^3.24.0"
+  },
+  "optionalDependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
+    "openai": "^4.90.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -8,7 +8,12 @@ import { findRelatedTests } from '../../core/tests/findRelatedTests.ts'
 import { getGitSignals } from '../../core/git/getGitSignals.ts'
 import { buildBasicNote } from '../../core/output/buildBasicNote.ts'
 import { writeJsonNote } from '../../core/output/writeJsonNote.ts'
+import { writeMarkdownNote } from '../../core/output/writeMarkdownNote.ts'
+import { createProvider } from '../../core/llm/provider/factory.ts'
+import { synthesizeFileNote } from '../../core/llm/synthesizeFileNote.ts'
 import { logger } from '../../core/utils/logger.ts'
+
+const DEFAULT_LLM_THRESHOLD = 0.4
 
 export async function runGenerate(args: { root?: string }): Promise<void> {
   const root = path.resolve(args.root ?? process.cwd())
@@ -29,34 +34,50 @@ export async function runGenerate(args: { root?: string }): Promise<void> {
   const depGraph = buildDependencyGraph(analyses, root)
   const revGraph = buildReverseDependencyGraph(depGraph)
 
-  // 4. Git intelligence
-  logger.info('Extracting git signals...')
+  // 4. Setup LLM provider (if configured)
+  const llmConfig = config.llm
+  const provider = llmConfig ? createProvider(llmConfig) : null
+  const llmThreshold = llmConfig?.llmThreshold ?? DEFAULT_LLM_THRESHOLD
+  const temperature = llmConfig?.temperature ?? 0.2
+
+  if (provider) {
+    logger.info(`LLM synthesis enabled (provider: ${llmConfig!.provider}, threshold: ${llmThreshold})`)
+  }
 
   // 5. Generate and write notes
   logger.info('Writing notes...')
   let written = 0
+  let synthesized = 0
 
   for (const analysis of analyses) {
     const relatedTests = findRelatedTests(analysis.filePath, files)
     const gitSignals = getGitSignals(analysis.filePath, root)
 
-    const note = buildBasicNote(
-      analysis,
-      {
-        filePath: analysis.filePath,
-        directDependencies: depGraph.get(analysis.filePath) ?? [],
-        reverseDependencies: revGraph.get(analysis.filePath) ?? [],
-      },
-      {
-        filePath: analysis.filePath,
-        relatedTests,
-      },
-      gitSignals,
-    )
+    const graph = {
+      filePath: analysis.filePath,
+      directDependencies: depGraph.get(analysis.filePath) ?? [],
+      reverseDependencies: revGraph.get(analysis.filePath) ?? [],
+    }
+    const tests = { filePath: analysis.filePath, relatedTests }
+
+    // Build static note first
+    let note = buildBasicNote(analysis, graph, tests, gitSignals)
+
+    // LLM synthesis for critical files
+    if (provider && note.criticalityScore >= llmThreshold) {
+      note = await synthesizeFileNote(
+        { analysis, graph, tests, git: gitSignals, staticNote: note },
+        provider,
+        temperature,
+      )
+      synthesized++
+    }
 
     await writeJsonNote(note, root, config.output)
+    await writeMarkdownNote(note, root, config.output)
     written++
   }
 
   logger.success(`Generated ${written} notes in ${config.output}/`)
+  if (provider) logger.info(`LLM synthesized: ${synthesized} files`)
 }

--- a/src/core/llm/prompts/buildPrompt.ts
+++ b/src/core/llm/prompts/buildPrompt.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs'
+import type { StaticFileAnalysis, GraphSignals, TestSignals, GitSignals } from '../../types/file-analysis.ts'
+import type { AiFileNote } from '../../types/ai-note.ts'
+
+const MAX_SOURCE_LINES = 200
+
+export type PromptContext = {
+  analysis: StaticFileAnalysis
+  graph: GraphSignals
+  tests: TestSignals
+  git: GitSignals
+  staticNote: AiFileNote
+}
+
+export function buildPrompt(ctx: PromptContext): string {
+  const { analysis, graph, tests, git, staticNote } = ctx
+
+  const sourceCode = readSourceTruncated(analysis.filePath)
+
+  const staticContext = {
+    imports: analysis.imports,
+    exports: analysis.exports,
+    hooks: analysis.hooks,
+    envVars: analysis.envVars,
+    apiCalls: analysis.apiCalls,
+    comments: analysis.comments,
+    hasSideEffects: analysis.hasSideEffects,
+  }
+
+  const existingObserved = {
+    purpose: staticNote.purpose.observed,
+    sensitiveDependencies: staticNote.sensitiveDependencies.observed,
+    knownPitfalls: staticNote.knownPitfalls.observed,
+    impactValidation: staticNote.impactValidation.observed,
+  }
+
+  return `Analyze the file below and generate an operational note.
+
+File: ${analysis.filePath}
+
+Static context:
+${JSON.stringify(staticContext, null, 2)}
+
+Reverse dependencies (consumers):
+${graph.reverseDependencies.slice(0, 5).join('\n') || 'none'}
+
+Git signals:
+${JSON.stringify({ churnScore: git.churnScore, recentCommitMessages: git.recentCommitMessages, coChangedFiles: git.coChangedFiles.slice(0, 5), authorCount: git.authorCount }, null, 2)}
+
+Related tests:
+${tests.relatedTests.join('\n') || 'none'}
+
+Already observed (do not repeat, use as context):
+${JSON.stringify(existingObserved, null, 2)}
+
+Source code:
+\`\`\`typescript
+${sourceCode}
+\`\`\`
+
+Return a JSON object with these fields. Each field follows the StructuredListField schema:
+{
+  "purpose": { "observed": [], "inferred": [], "confidence": 0.0, "evidence": [] },
+  "invariants": { "observed": [], "inferred": [], "confidence": 0.0, "evidence": [] },
+  "sensitiveDependencies": { "observed": [], "inferred": [], "confidence": 0.0, "evidence": [] },
+  "importantDecisions": { "observed": [], "inferred": [], "confidence": 0.0, "evidence": [] },
+  "knownPitfalls": { "observed": [], "inferred": [], "confidence": 0.0, "evidence": [] },
+  "impactValidation": { "observed": [], "inferred": [], "confidence": 0.0, "evidence": [] }
+}
+
+evidence items: { "type": "code"|"git"|"test"|"graph"|"comment"|"doc", "detail": "string" }
+Return ONLY the JSON object, no markdown wrapping.`
+}
+
+function readSourceTruncated(filePath: string): string {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8')
+    const lines = content.split('\n')
+    if (lines.length <= MAX_SOURCE_LINES) return content
+    return lines.slice(0, MAX_SOURCE_LINES).join('\n') + `\n// ... (truncated at ${MAX_SOURCE_LINES} lines)`
+  } catch {
+    return '// source not available'
+  }
+}

--- a/src/core/llm/prompts/systemPrompt.ts
+++ b/src/core/llm/prompts/systemPrompt.ts
@@ -1,0 +1,12 @@
+export const SYSTEM_PROMPT = `You are a software analyst specialized in generating operational notes per file.
+
+Rules:
+- Use only the evidence provided. Do not invent facts.
+- Separate observed (extracted from code/git/tests) from inferred (your synthesis).
+- Be technical and concise.
+- Fill "importantDecisions" only when there are real signals in code, comments, docs or Git.
+- When something is unclear, reduce confidence and leave the field empty or partial.
+- Return valid JSON following the requested schema exactly.
+- confidence must be a number between 0 and 1.
+- evidence items must have type ("code" | "git" | "test" | "graph" | "comment" | "doc") and detail (string).
+- Fields can be empty arrays when there is insufficient evidence.`

--- a/src/core/llm/provider/anthropic.ts
+++ b/src/core/llm/provider/anthropic.ts
@@ -1,0 +1,34 @@
+import type { LLMProvider, LLMRequest, LLMResponse } from './types.ts'
+
+const DEFAULT_MODEL = 'claude-sonnet-4-6'
+
+export class AnthropicProvider implements LLMProvider {
+  private apiKey: string
+  private model: string
+
+  constructor(opts: { apiKey: string; model?: string }) {
+    this.apiKey = opts.apiKey
+    this.model = opts.model ?? DEFAULT_MODEL
+  }
+
+  async complete(request: LLMRequest): Promise<LLMResponse> {
+    // Dynamic import so @anthropic-ai/sdk is truly optional
+    const { default: Anthropic } = await import('@anthropic-ai/sdk')
+    const client = new Anthropic({ apiKey: this.apiKey })
+
+    const message = await client.messages.create({
+      model: this.model,
+      max_tokens: 4096,
+      temperature: request.temperature ?? 0.2,
+      system: request.system,
+      messages: [{ role: 'user', content: request.user }],
+    })
+
+    const content = message.content
+      .filter((b) => b.type === 'text')
+      .map((b) => (b as { type: 'text'; text: string }).text)
+      .join('')
+
+    return { content, model: this.model }
+  }
+}

--- a/src/core/llm/provider/factory.ts
+++ b/src/core/llm/provider/factory.ts
@@ -1,0 +1,30 @@
+import type { LLMProvider } from './types.ts'
+import type { LLMConfig } from '../../types/project.ts'
+import { OllamaProvider } from './ollama.ts'
+import { AnthropicProvider } from './anthropic.ts'
+import { OpenAIProvider } from './openai.ts'
+
+export function createProvider(config: LLMConfig): LLMProvider {
+  switch (config.provider) {
+    case 'ollama':
+      return new OllamaProvider({
+        baseUrl: config.baseUrl,
+        model: config.model,
+      })
+
+    case 'anthropic': {
+      const apiKey = config.apiKey ?? process.env.ANTHROPIC_API_KEY
+      if (!apiKey) throw new Error('Anthropic provider requires apiKey or ANTHROPIC_API_KEY env var')
+      return new AnthropicProvider({ apiKey, model: config.model })
+    }
+
+    case 'openai': {
+      const apiKey = config.apiKey ?? process.env.OPENAI_API_KEY
+      if (!apiKey) throw new Error('OpenAI provider requires apiKey or OPENAI_API_KEY env var')
+      return new OpenAIProvider({ apiKey, model: config.model })
+    }
+
+    default:
+      throw new Error(`Unknown LLM provider: ${(config as LLMConfig).provider}`)
+  }
+}

--- a/src/core/llm/provider/ollama.ts
+++ b/src/core/llm/provider/ollama.ts
@@ -1,0 +1,37 @@
+import type { LLMProvider, LLMRequest, LLMResponse } from './types.ts'
+
+const DEFAULT_BASE_URL = 'http://localhost:11434'
+const DEFAULT_MODEL = 'llama3'
+
+export class OllamaProvider implements LLMProvider {
+  private baseUrl: string
+  private model: string
+
+  constructor(opts: { baseUrl?: string; model?: string } = {}) {
+    this.baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL
+    this.model = opts.model ?? DEFAULT_MODEL
+  }
+
+  async complete(request: LLMRequest): Promise<LLMResponse> {
+    const response = await fetch(`${this.baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: this.model,
+        stream: false,
+        options: { temperature: request.temperature ?? 0.2 },
+        messages: [
+          { role: 'system', content: request.system },
+          { role: 'user', content: request.user },
+        ],
+      }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Ollama request failed: ${response.status} ${response.statusText}`)
+    }
+
+    const data = await response.json() as { message: { content: string } }
+    return { content: data.message.content, model: this.model }
+  }
+}

--- a/src/core/llm/provider/openai.ts
+++ b/src/core/llm/provider/openai.ts
@@ -1,0 +1,31 @@
+import type { LLMProvider, LLMRequest, LLMResponse } from './types.ts'
+
+const DEFAULT_MODEL = 'gpt-4o'
+
+export class OpenAIProvider implements LLMProvider {
+  private apiKey: string
+  private model: string
+
+  constructor(opts: { apiKey: string; model?: string }) {
+    this.apiKey = opts.apiKey
+    this.model = opts.model ?? DEFAULT_MODEL
+  }
+
+  async complete(request: LLMRequest): Promise<LLMResponse> {
+    // Dynamic import so openai SDK is truly optional
+    const { default: OpenAI } = await import('openai')
+    const client = new OpenAI({ apiKey: this.apiKey })
+
+    const completion = await client.chat.completions.create({
+      model: this.model,
+      temperature: request.temperature ?? 0.2,
+      messages: [
+        { role: 'system', content: request.system },
+        { role: 'user', content: request.user },
+      ],
+    })
+
+    const content = completion.choices[0]?.message.content ?? ''
+    return { content, model: this.model }
+  }
+}

--- a/src/core/llm/provider/types.ts
+++ b/src/core/llm/provider/types.ts
@@ -1,0 +1,14 @@
+export type LLMRequest = {
+  system: string
+  user: string
+  temperature?: number
+}
+
+export type LLMResponse = {
+  content: string
+  model: string
+}
+
+export interface LLMProvider {
+  complete(request: LLMRequest): Promise<LLMResponse>
+}

--- a/src/core/llm/schemas/aiNoteSchema.ts
+++ b/src/core/llm/schemas/aiNoteSchema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+
+const evidenceItemSchema = z.object({
+  type: z.enum(['code', 'git', 'test', 'graph', 'comment', 'doc']),
+  detail: z.string(),
+})
+
+const structuredListFieldSchema = z.object({
+  observed: z.array(z.string()).default([]),
+  inferred: z.array(z.string()).default([]),
+  confidence: z.number().min(0).max(1),
+  evidence: z.array(evidenceItemSchema).default([]),
+})
+
+export const llmNoteSchema = z.object({
+  purpose: structuredListFieldSchema,
+  invariants: structuredListFieldSchema,
+  sensitiveDependencies: structuredListFieldSchema,
+  importantDecisions: structuredListFieldSchema,
+  knownPitfalls: structuredListFieldSchema,
+  impactValidation: structuredListFieldSchema,
+})
+
+export type LLMNotePayload = z.infer<typeof llmNoteSchema>

--- a/src/core/llm/synthesizeFileNote.ts
+++ b/src/core/llm/synthesizeFileNote.ts
@@ -1,0 +1,73 @@
+import type { AiFileNote } from '../types/ai-note.ts'
+import type { LLMProvider } from './provider/types.ts'
+import { buildPrompt, type PromptContext } from './prompts/buildPrompt.ts'
+import { SYSTEM_PROMPT } from './prompts/systemPrompt.ts'
+import { llmNoteSchema } from './schemas/aiNoteSchema.ts'
+import { logger } from '../utils/logger.ts'
+
+export async function synthesizeFileNote(
+  ctx: PromptContext,
+  provider: LLMProvider,
+  temperature: number = 0.2,
+): Promise<AiFileNote> {
+  const staticNote = ctx.staticNote
+
+  try {
+    const userPrompt = buildPrompt(ctx)
+    const response = await provider.complete({
+      system: SYSTEM_PROMPT,
+      user: userPrompt,
+      temperature,
+    })
+
+    const parsed = parseJSON(response.content)
+    const validated = llmNoteSchema.safeParse(parsed)
+
+    if (!validated.success) {
+      logger.warn(`LLM response failed validation for ${ctx.analysis.filePath}: ${validated.error.message}`)
+      return staticNote
+    }
+
+    const llm = validated.data
+
+    // Merge: observed comes from static note, inferred + updated confidence from LLM
+    return {
+      ...staticNote,
+      model: response.model,
+      purpose: merge(staticNote.purpose, llm.purpose),
+      invariants: merge(staticNote.invariants, llm.invariants),
+      sensitiveDependencies: merge(staticNote.sensitiveDependencies, llm.sensitiveDependencies),
+      importantDecisions: merge(staticNote.importantDecisions, llm.importantDecisions),
+      knownPitfalls: merge(staticNote.knownPitfalls, llm.knownPitfalls),
+      impactValidation: merge(staticNote.impactValidation, llm.impactValidation),
+    }
+  } catch (err) {
+    logger.warn(`LLM synthesis failed for ${ctx.analysis.filePath}: ${(err as Error).message}`)
+    return staticNote
+  }
+}
+
+function merge(
+  staticField: AiFileNote['purpose'],
+  llmField: AiFileNote['purpose'],
+): AiFileNote['purpose'] {
+  return {
+    observed: staticField.observed,
+    inferred: llmField.inferred,
+    confidence: llmField.confidence,
+    evidence: [
+      ...staticField.evidence,
+      ...llmField.evidence.filter((e) => !staticField.evidence.some((s) => s.detail === e.detail)),
+    ],
+  }
+}
+
+function parseJSON(raw: string): unknown {
+  // Strip markdown code block if present
+  const stripped = raw
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```\s*$/, '')
+    .trim()
+
+  return JSON.parse(stripped)
+}

--- a/src/core/output/writeMarkdownNote.ts
+++ b/src/core/output/writeMarkdownNote.ts
@@ -1,0 +1,76 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import type { AiFileNote, StructuredListField } from '../types/ai-note.ts'
+
+export async function writeMarkdownNote(
+  note: AiFileNote,
+  root: string,
+  outputDir: string,
+): Promise<string> {
+  const relativePath = path.relative(root, note.filePath)
+  const outputPath = path.resolve(root, outputDir, relativePath + '.md')
+  const outputFolder = path.dirname(outputPath)
+
+  await fs.mkdir(outputFolder, { recursive: true })
+  await fs.writeFile(outputPath, renderMarkdown(note, relativePath), 'utf-8')
+
+  return outputPath
+}
+
+function renderMarkdown(note: AiFileNote, relativePath: string): string {
+  const date = new Date(note.generatedAt).toISOString().slice(0, 10)
+  const score = note.criticalityScore.toFixed(2)
+
+  const sections = [
+    `# ${relativePath}`,
+    ``,
+    `**Criticality:** ${score} | **Generated:** ${date} | **Model:** ${note.model}`,
+    ``,
+    renderSection('Purpose', note.purpose),
+    renderSection('Invariants', note.invariants),
+    renderSection('Sensitive Dependencies', note.sensitiveDependencies),
+    renderSection('Important Decisions', note.importantDecisions),
+    renderSection('Known Pitfalls', note.knownPitfalls),
+    renderSection('Impact Validation', note.impactValidation),
+  ]
+
+  return sections.filter((s) => s !== null).join('\n')
+}
+
+function renderSection(title: string, field: StructuredListField): string {
+  const hasContent =
+    field.observed.length > 0 ||
+    field.inferred.length > 0 ||
+    field.evidence.length > 0
+
+  if (!hasContent) return ''
+
+  const lines: string[] = [`## ${title}`, ``]
+
+  if (field.observed.length > 0) {
+    for (const item of field.observed) {
+      lines.push(`- ${item}`)
+    }
+  }
+
+  if (field.inferred.length > 0) {
+    lines.push(``)
+    lines.push(`> **Inferred** (confidence: ${field.confidence.toFixed(2)}):`)
+    for (const item of field.inferred) {
+      lines.push(`> - ${item}`)
+    }
+  }
+
+  if (field.evidence.length > 0) {
+    lines.push(``)
+    lines.push(`| Type | Detail |`)
+    lines.push(`|------|--------|`)
+    for (const e of field.evidence) {
+      const detail = e.detail.replace(/\|/g, '\\|')
+      lines.push(`| ${e.type} | ${detail} |`)
+    }
+  }
+
+  lines.push(``)
+  return lines.join('\n')
+}

--- a/src/core/types/project.ts
+++ b/src/core/types/project.ts
@@ -5,10 +5,22 @@ export type DiscoveredFile = {
   size: number
 }
 
+export type LLMProviderName = 'ollama' | 'anthropic' | 'openai'
+
+export type LLMConfig = {
+  provider: LLMProviderName
+  model?: string
+  baseUrl?: string
+  apiKey?: string
+  llmThreshold?: number
+  temperature?: number
+}
+
 export type AiNotesConfig = {
   root: string
   include: string[]
   exclude: string[]
   output: string
   tsconfigPath?: string
+  llm?: LLMConfig
 }

--- a/tests/llm/factory.test.ts
+++ b/tests/llm/factory.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'bun:test'
+import { createProvider } from '../../src/core/llm/provider/factory.ts'
+import { OllamaProvider } from '../../src/core/llm/provider/ollama.ts'
+
+describe('createProvider', () => {
+  it('creates an OllamaProvider for provider "ollama"', () => {
+    const provider = createProvider({ provider: 'ollama', model: 'llama3' })
+    expect(provider).toBeInstanceOf(OllamaProvider)
+  })
+
+  it('throws for anthropic without apiKey', () => {
+    const orig = process.env.ANTHROPIC_API_KEY
+    delete process.env.ANTHROPIC_API_KEY
+    expect(() => createProvider({ provider: 'anthropic' })).toThrow()
+    process.env.ANTHROPIC_API_KEY = orig
+  })
+
+  it('throws for openai without apiKey', () => {
+    const orig = process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_API_KEY
+    expect(() => createProvider({ provider: 'openai' })).toThrow()
+    process.env.OPENAI_API_KEY = orig
+  })
+})

--- a/tests/llm/synthesizeFileNote.test.ts
+++ b/tests/llm/synthesizeFileNote.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, mock } from 'bun:test'
+import { synthesizeFileNote } from '../../src/core/llm/synthesizeFileNote.ts'
+import type { LLMProvider } from '../../src/core/llm/provider/types.ts'
+import type { StaticFileAnalysis, GraphSignals, TestSignals, GitSignals } from '../../src/core/types/file-analysis.ts'
+import type { AiFileNote } from '../../src/core/types/ai-note.ts'
+
+function makeStaticNote(overrides: Partial<AiFileNote> = {}): AiFileNote {
+  const empty = { observed: [], inferred: [], confidence: 0, evidence: [] }
+  return {
+    filePath: '/project/src/useSearch.ts',
+    purpose: { observed: ['Exports hooks: useSearch'], inferred: [], confidence: 0.6, evidence: [] },
+    invariants: empty,
+    sensitiveDependencies: empty,
+    importantDecisions: empty,
+    knownPitfalls: empty,
+    impactValidation: empty,
+    criticalityScore: 0.5,
+    generatedAt: new Date().toISOString(),
+    model: 'static',
+    ...overrides,
+  }
+}
+
+function makeCtx(staticNote: AiFileNote) {
+  const analysis: StaticFileAnalysis = {
+    filePath: staticNote.filePath,
+    imports: [], localImports: [], externalImports: [],
+    exports: ['useSearch'], symbols: ['useSearch'], hooks: ['useSearch'],
+    envVars: [], apiCalls: [],
+    comments: { todo: [], fixme: [], hack: [] },
+    hasSideEffects: false,
+  }
+  const graph: GraphSignals = { filePath: staticNote.filePath, directDependencies: [], reverseDependencies: [] }
+  const tests: TestSignals = { filePath: staticNote.filePath, relatedTests: [] }
+  const git: GitSignals = { filePath: staticNote.filePath, churnScore: 0, recentCommitMessages: [], coChangedFiles: [], authorCount: 0 }
+  return { analysis, graph, tests, git, staticNote }
+}
+
+const validLLMResponse = JSON.stringify({
+  purpose: { observed: [], inferred: ['Orchestrates image search flow'], confidence: 0.89, evidence: [{ type: 'code', detail: 'export function useSearch' }] },
+  invariants: { observed: [], inferred: ['Must preserve shape expected by consumers'], confidence: 0.75, evidence: [] },
+  sensitiveDependencies: { observed: [], inferred: [], confidence: 0, evidence: [] },
+  importantDecisions: { observed: [], inferred: [], confidence: 0, evidence: [] },
+  knownPitfalls: { observed: [], inferred: [], confidence: 0, evidence: [] },
+  impactValidation: { observed: [], inferred: [], confidence: 0, evidence: [] },
+})
+
+describe('synthesizeFileNote', () => {
+  it('merges LLM inferred into static observed', async () => {
+    const provider: LLMProvider = {
+      complete: async () => ({ content: validLLMResponse, model: 'llama3' }),
+    }
+
+    const staticNote = makeStaticNote()
+    const result = await synthesizeFileNote(makeCtx(staticNote), provider)
+
+    expect(result.model).toBe('llama3')
+    expect(result.purpose.observed).toEqual(staticNote.purpose.observed)
+    expect(result.purpose.inferred).toContain('Orchestrates image search flow')
+    expect(result.invariants.inferred).toContain('Must preserve shape expected by consumers')
+  })
+
+  it('falls back to static note on invalid LLM response', async () => {
+    const provider: LLMProvider = {
+      complete: async () => ({ content: '{ invalid json }}}', model: 'llama3' }),
+    }
+
+    const staticNote = makeStaticNote()
+    const result = await synthesizeFileNote(makeCtx(staticNote), provider)
+
+    expect(result.model).toBe('static')
+    expect(result).toEqual(staticNote)
+  })
+
+  it('falls back to static note on LLM error', async () => {
+    const provider: LLMProvider = {
+      complete: async () => { throw new Error('connection refused') },
+    }
+
+    const staticNote = makeStaticNote()
+    const result = await synthesizeFileNote(makeCtx(staticNote), provider)
+
+    expect(result.model).toBe('static')
+  })
+
+  it('falls back to static note on schema validation failure', async () => {
+    const provider: LLMProvider = {
+      complete: async () => ({ content: JSON.stringify({ purpose: 'wrong shape' }), model: 'llama3' }),
+    }
+
+    const staticNote = makeStaticNote()
+    const result = await synthesizeFileNote(makeCtx(staticNote), provider)
+
+    expect(result.model).toBe('static')
+  })
+})

--- a/tests/output/writeMarkdownNote.test.ts
+++ b/tests/output/writeMarkdownNote.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from 'bun:test'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { writeMarkdownNote } from '../../src/core/output/writeMarkdownNote.ts'
+import type { AiFileNote } from '../../src/core/types/ai-note.ts'
+
+const TMP_OUTPUT = path.resolve(import.meta.dir, '../../.tmp-test-md')
+
+afterEach(async () => {
+  await fs.rm(TMP_OUTPUT, { recursive: true, force: true })
+})
+
+function makeNote(overrides: Partial<AiFileNote> = {}): AiFileNote {
+  const empty = { observed: [], inferred: [], confidence: 0, evidence: [] }
+  return {
+    filePath: '/project/src/useSearch.ts',
+    purpose: {
+      observed: ['Exports hooks: useSearch'],
+      inferred: ['Orchestrates search flow'],
+      confidence: 0.89,
+      evidence: [{ type: 'code', detail: 'export function useSearch' }],
+    },
+    invariants: empty,
+    sensitiveDependencies: {
+      observed: ['SearchScreen.tsx'],
+      inferred: [],
+      confidence: 0.85,
+      evidence: [{ type: 'graph', detail: 'Reverse dep: SearchScreen.tsx' }],
+    },
+    importantDecisions: empty,
+    knownPitfalls: {
+      observed: ['TODO: remove legacy fallback'],
+      inferred: [],
+      confidence: 0.9,
+      evidence: [{ type: 'comment', detail: 'TODO: remove legacy fallback' }],
+    },
+    impactValidation: empty,
+    criticalityScore: 0.72,
+    generatedAt: '2026-03-28T00:00:00.000Z',
+    model: 'llama3',
+    ...overrides,
+  }
+}
+
+describe('writeMarkdownNote', () => {
+  it('creates a .md file at the correct path', async () => {
+    const note = makeNote()
+    const outputPath = await writeMarkdownNote(note, '/project', TMP_OUTPUT)
+    expect(outputPath.endsWith('.md')).toBe(true)
+    const exists = await fs.access(outputPath).then(() => true).catch(() => false)
+    expect(exists).toBe(true)
+  })
+
+  it('includes file path and model in header', async () => {
+    const note = makeNote()
+    const outputPath = await writeMarkdownNote(note, '/project', TMP_OUTPUT)
+    const content = await fs.readFile(outputPath, 'utf-8')
+    expect(content).toContain('src/useSearch.ts')
+    expect(content).toContain('llama3')
+    expect(content).toContain('0.72')
+  })
+
+  it('renders observed and inferred items', async () => {
+    const note = makeNote()
+    const outputPath = await writeMarkdownNote(note, '/project', TMP_OUTPUT)
+    const content = await fs.readFile(outputPath, 'utf-8')
+    expect(content).toContain('Exports hooks: useSearch')
+    expect(content).toContain('Orchestrates search flow')
+  })
+
+  it('renders evidence table', async () => {
+    const note = makeNote()
+    const outputPath = await writeMarkdownNote(note, '/project', TMP_OUTPUT)
+    const content = await fs.readFile(outputPath, 'utf-8')
+    expect(content).toContain('| code |')
+    expect(content).toContain('export function useSearch')
+  })
+
+  it('skips empty sections', async () => {
+    const note = makeNote()
+    const outputPath = await writeMarkdownNote(note, '/project', TMP_OUTPUT)
+    const content = await fs.readFile(outputPath, 'utf-8')
+    expect(content).not.toContain('## Invariants')
+    expect(content).not.toContain('## Important Decisions')
+  })
+})


### PR DESCRIPTION
## Contexto

Fase 3 do braito. Adiciona síntese semântica via LLM e geração de sidecar Markdown. O pipeline passa a ser:

```
scan → parse → graph → git → static note → [LLM synthesis] → write .json + .md
```

---

## Provider abstraction — `src/core/llm/provider/`

Provider dinâmico com interface comum — troca de LLM sem mudar o pipeline.

| Arquivo | Responsabilidade |
|---|---|
| `types.ts` | Interface `LLMProvider` com método `complete(LLMRequest): Promise<LLMResponse>` |
| `ollama.ts` | Fetch nativo para `http://localhost:11434/api/chat`. Sem SDK, funciona out-of-the-box com Ollama local |
| `anthropic.ts` | `@anthropic-ai/sdk` via dynamic import (optional dep) |
| `openai.ts` | `openai` SDK via dynamic import (optional dep) |
| `factory.ts` | `createProvider(config)` seleciona por `config.llm.provider`; lê API keys de config ou env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) |

---

## Prompt & Validação

- **`systemPrompt.ts`** — instrui o modelo a separar `observed` de `inferred`, não inventar fatos, retornar JSON estrito
- **`buildPrompt.ts`** — monta user prompt com: análise estática, dependências reversas (top 5), sinais Git, testes relacionados, campos `observed` já preenchidos (como contexto), e código-fonte truncado em 200 linhas
- **`schemas/aiNoteSchema.ts`** — Zod schema validando todos os `StructuredListField` da resposta

---

## Synthesizer — `synthesizeFileNote.ts`

Fluxo:
1. Monta prompt
2. Chama provider
3. Strip de markdown code block na resposta (se presente)
4. Valida com Zod
5. **Merge**: `observed` vem da nota estática, `inferred` + `confidence` vêm do LLM, `evidence` é union deduplicada
6. Fallback silencioso para nota estática em qualquer erro (timeout, JSON inválido, schema inválido)

---

## Markdown sidecar — `writeMarkdownNote.ts`

Gera `.md` junto com o `.json`:
- Header com criticality score, data e model
- Seções por campo (`Purpose`, `Invariants`, etc.)
- Seções vazias são omitidas
- Itens `inferred` renderizados como blockquote com confidence
- Tabela de evidências por seção

Exemplo de output:
```markdown
# src/core/output/buildBasicNote.ts

**Criticality:** 0.72 | **Generated:** 2026-03-28 | **Model:** llama3

## Purpose
- Exports hooks: useSearch

> **Inferred** (confidence: 0.89):
> - Orchestrates the search flow and prepares results for consumers

| Type | Detail |
|------|--------|
| code | export function useSearch |
```

---

## Config — `AiNotesConfig`

```ts
llm?: {
  provider: 'ollama' | 'anthropic' | 'openai'
  model?: string
  baseUrl?: string       // Ollama customizado
  apiKey?: string        // ou ANTHROPIC_API_KEY / OPENAI_API_KEY
  llmThreshold?: number  // padrão 0.4 — só sintetiza arquivos com criticalityScore >= threshold
  temperature?: number   // padrão 0.2
}
```

---

## Como testar com Ollama

```bash
# 1. Subir Ollama
ollama run llama3

# 2. Descomentar config em ai-notes.config.ts:
# llm: { provider: 'ollama', model: 'llama3', llmThreshold: 0.4 }

# 3. Rodar
bun src/cli/index.ts generate --root ./

# 4. Verificar
cat .ai-notes/src/core/output/buildBasicNote.ts.json  # model != "static"
cat .ai-notes/src/core/output/buildBasicNote.ts.md    # Markdown renderizado
```

---

## Testes — 3 novas suítes

| Arquivo | Cobertura |
|---|---|
| `tests/llm/synthesizeFileNote.test.ts` | Merge correto, fallback em JSON inválido, fallback em erro de provider, fallback em falha de schema |
| `tests/llm/factory.test.ts` | Criação de OllamaProvider, erro sem apiKey para Anthropic/OpenAI |
| `tests/output/writeMarkdownNote.test.ts` | Criação do arquivo, header, observed/inferred, tabela de evidência, omissão de seções vazias |

---

## O que fica para a Fase 4

- Cache por hash (evitar reprocessar arquivos não alterados)
- Watch mode
- Índice geral por criticidade
- CI integration

🤖 Generated with [Claude Code](https://claude.ai/claude-code)