### PR TITLE
feat: Phase 4 — cache, index, watch mode and CI integration

### DIFF
--- a/.github/workflows/ai-notes.yml
+++ b/.github/workflows/ai-notes.yml
@@ -1,0 +1,46 @@
+name: Update AI Notes
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'src/**'
+      - 'packages/**'
+      - '*.ts'
+      - '*.tsx'
+
+jobs:
+  generate:
+    name: Generate AI Notes
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout (full history for git signals)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate notes
+        run: bun src/cli/index.ts generate --root .
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Commit updated notes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .ai-notes/ cache/
+          git diff --cached --quiet || git commit -m "chore: update ai notes [skip ci]"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,17 +6,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **braito** (AI File Notes) is a TypeScript CLI tool that analyzes codebases and generates operational knowledge sidecars (`.json` + `.md`) per file. It targets dense TypeScript/JavaScript monorepos and teams using AI for code review, onboarding, and maintenance.
 
-This project is currently in the **documentation/planning phase** — no source code exists yet. The `docs/` directory contains the full design.
+**All 4 phases are implemented.** The tool is fully operational.
 
-## Planned CLI Commands
-
-Once implemented, the tool will be invoked as:
+## CLI Commands
 
 ```bash
-ai-notes scan       # discover eligible files
-ai-notes generate   # run analysis and synthesize notes
-ai-notes publish    # write .json and .md sidecars
-ai-notes watch      # incremental watch mode
+bun install                                        # install dependencies
+bun src/cli/index.ts scan --root ./                # discover and list eligible files
+bun src/cli/index.ts generate --root ./            # full pipeline — writes .ai-notes/
+bun src/cli/index.ts generate --root ./ --force    # bypass cache, reprocess all files
+bun src/cli/index.ts watch --root ./               # watch mode — regenerates on file change
+bun test                                           # run all test suites
 ```
 
 ## Architecture
@@ -25,29 +25,30 @@ The pipeline flows linearly:
 
 ```
 repo → scanner → static analyzer → graph engine → git intelligence
-     → test intelligence → context builder → llm synthesizer → publisher
+     → [cache check] → static note → [LLM synthesis] → write .json + .md + index
 ```
 
-Key design constraint: **LLM sits at the synthesis edge only** — the majority of the pipeline is deterministic and auditable. Never send the full repo to the model; send minimal, evidence-rich context per file.
+**Key constraint:** LLM sits at the synthesis edge only. The majority of the pipeline is deterministic and auditable. Files are only sent to LLM when `criticalityScore >= llmThreshold` (default `0.4`).
 
 ### Layer breakdown
 
 | Layer | Path | Responsibility |
 |---|---|---|
-| CLI | `src/cli/` | Command orchestration only, no business logic |
-| Core | `src/core/` | All business logic — parsing, graph, git, context, ranking |
+| CLI | `src/cli/` | Command orchestration — `scan`, `generate`, `watch` |
+| Core | `src/core/` | All business logic |
 | Output | `src/core/output/` | JSON/Markdown serialization, sidecar writing, index building |
+| Cache | `src/core/cache/` | SHA-1 hash per file, skip unchanged files |
 
 ### Core modules
 
-- **`core/scanner/`** — file discovery with include/exclude/ignore rules
-- **`core/ast/`** — modular by language; MVP targets TS/TSX via `ts-morph` or TypeScript Compiler API; designed for future language expansion
-- **`core/graph/`** — direct + reverse dependency graphs; central to impact/criticality scoring
-- **`core/git/`** — churn scores, recent commits, co-changed files, blame hints
-- **`core/tests/`** — maps related tests by name, imports, folder proximity, co-change
-- **`core/context/`** — assembles `FileContextPacket` per file; no parsing logic here
-- **`core/llm/`** — separated into: provider, prompts, schemas, synthesizer
-- **`core/ranking/`** — criticality and confidence scoring
+- **`core/scanner/`** — file discovery with `Bun.Glob`, include/exclude/ignore rules
+- **`core/ast/`** — `ts-morph` based; extractors for imports, exports, symbols, hooks, comments (TODO/FIXME/HACK), env vars, API calls
+- **`core/graph/`** — direct + reverse dependency graphs; `resolveImportPath` handles relative paths and `tsconfig.paths` aliases
+- **`core/git/`** — churn score, recent commit messages, co-changed files, author count via `git` CLI + `Bun.spawnSync`
+- **`core/tests/`** — heuristic test discovery by name, `__tests__` folder proximity
+- **`core/cache/`** — SHA-1 hash per file, `cache/hashes.json`, skip unchanged files between runs
+- **`core/llm/`** — provider abstraction (`ollama`, `anthropic`, `openai`), prompt builder, Zod schema validation, merge strategy
+- **`core/output/`** — `buildBasicNote`, `writeJsonNote`, `writeMarkdownNote`, `buildIndex`, `writeIndexNote`
 
 ## Domain Model
 
@@ -62,43 +63,82 @@ type AiFileNote = {
   importantDecisions: StructuredListField
   knownPitfalls: StructuredListField
   impactValidation: StructuredListField
-  criticalityScore: number
+  criticalityScore: number   // 0–1, heuristic based on consumers, churn, hooks, tests
   generatedAt: string
-  model: string
+  model: string              // "static" | "<llm-model-name>"
+}
+
+type StructuredListField = {
+  observed: string[]         // facts from static analysis / git / tests
+  inferred: string[]         // LLM synthesis (empty when model = "static")
+  confidence: number         // 0–1
+  evidence: EvidenceItem[]   // type: 'code' | 'git' | 'test' | 'graph' | 'comment' | 'doc'
 }
 ```
 
-### Structured fields always contain
+The `observed`/`inferred` split is mandatory — never collapse them.
+
+## LLM Configuration
+
+Configure in `ai-notes.config.ts`. Provider is dynamic — swap without changing the pipeline.
 
 ```ts
-type StructuredListField = {
-  observed: string[]   // facts extracted from code/git/tests
-  inferred: string[]   // LLM conclusions
-  confidence: number   // 0–1
-  evidence: EvidenceItem[]  // type: 'code' | 'git' | 'test' | 'graph' | 'comment' | 'doc'
-}
+// Ollama (local, no API key needed)
+llm: { provider: 'ollama', model: 'llama3', llmThreshold: 0.4, temperature: 0.2 }
+
+// Anthropic
+llm: { provider: 'anthropic', model: 'claude-sonnet-4-6', llmThreshold: 0.4 }
+// or set ANTHROPIC_API_KEY env var
+
+// OpenAI
+llm: { provider: 'openai', model: 'gpt-4o', llmThreshold: 0.4 }
+// or set OPENAI_API_KEY env var
 ```
 
-This `observed`/`inferred` split is mandatory — never collapse them.
-
-## Implementation Phases
-
-| Phase | Focus |
-|---|---|
-| 1 (MVP) | Scanner, TS/TSX parser, imports/exports, dependency graph, test discovery, JSON sidecar |
-| 2 | Git signals (churn, co-change, commit messages), criticality scoring |
-| 3 | LLM integration, Markdown sidecar, full structured schema |
-| 4 | Cache by hash, watch mode, CI integration, domain filters |
+LLM synthesis only runs for files where `criticalityScore >= llmThreshold`. Fallback to static note on any LLM error.
 
 ## Generated Output
 
-- `.ai-notes/` — generated sidecars; **do not edit manually**
-- `cache/` — intermediate hashes and results to avoid recomputation
+- `.ai-notes/<relative-path>.json` — structured note per file
+- `.ai-notes/<relative-path>.md` — human-readable sidecar
+- `.ai-notes/index.json` — all files ranked by criticality
+- `.ai-notes/index.md` — Markdown table with links
+- `cache/hashes.json` — SHA-1 per file for incremental runs
 
-## Key Design Principles
+Do not edit `.ai-notes/` or `cache/` manually.
 
-1. Base everything on static analysis first; LLM enriches at the end
-2. Always separate `observed` from `inferred` to reduce hallucination
-3. Every conclusion must carry `confidence` and `evidence`
-4. Sidecar-first approach — avoid inline code comments
-5. Prioritize: central hooks, adapters, gateways, high-churn files, reducers/stores, shared modules
+## CI
+
+`.github/workflows/ai-notes.yml` triggers on push to `main`/`master` when source files change. Requires full git history (`fetch-depth: 0`) for accurate git signals. Supports `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` as repository secrets.
+
+---
+
+## Next Steps
+
+### Short-term improvements
+
+**Alias resolution** — `resolveImportPath.ts` currently reads `tsconfig.paths` but does not handle bundler aliases (Vite, Webpack, Metro). Needed for accurate graphs in monorepos with custom path mappings.
+
+**Incremental graph rebuild** — currently the full dependency graph is rebuilt on every run even when using cache. In watch mode this is fine, but for large repos a partial rebuild (only affected files + their consumers) would be faster.
+
+**`--filter` flag** — allow `generate --filter packages/search/**` to scope the pipeline to a subdirectory or domain without changing config.
+
+**Confidence calibration** — the heuristic `criticalityScore` thresholds were set conservatively. After running against real monorepos, these weights should be tuned based on observed false positives/negatives.
+
+### Medium-term features
+
+**Markdown output for `invariants` and `importantDecisions`** — these fields are currently only filled by LLM. A heuristic pre-fill pass (pattern matching in comments, ADR files, changelog) would improve coverage even without LLM.
+
+**Domain grouping** — group files by folder/package in `index.md`, not just a flat ranked list. Useful for monorepos where each package has its own criticality context.
+
+**Stale note detection** — flag notes whose `generatedAt` is older than N days or whose source file has changed since last synthesis, prompting re-synthesis.
+
+**Test coverage hints** — integrate with coverage reports (lcov, c8) to surface actual uncovered files in `impactValidation`, not just heuristic test discovery.
+
+### Long-term / Phase 5 candidates
+
+**Multi-language support** — the AST layer was designed to be modular per language (`core/ast/analyzers/`). Adding Python (via tree-sitter) or Go support follows the same extractor pattern.
+
+**MCP server** — expose braito as a Model Context Protocol server so AI assistants (Cursor, Claude) can query notes about specific files on demand during code review.
+
+**Interactive UI** — a `bun src/cli/index.ts ui` command serving a local web interface to browse the index, filter by domain/score, and trigger re-synthesis.

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -9,13 +9,19 @@ import { getGitSignals } from '../../core/git/getGitSignals.ts'
 import { buildBasicNote } from '../../core/output/buildBasicNote.ts'
 import { writeJsonNote } from '../../core/output/writeJsonNote.ts'
 import { writeMarkdownNote } from '../../core/output/writeMarkdownNote.ts'
+import { buildIndex } from '../../core/output/buildIndex.ts'
+import { writeIndexNote } from '../../core/output/writeIndexNote.ts'
 import { createProvider } from '../../core/llm/provider/factory.ts'
 import { synthesizeFileNote } from '../../core/llm/synthesizeFileNote.ts'
+import { computeHash } from '../../core/cache/computeHash.ts'
+import { loadCache, saveCache } from '../../core/cache/cacheStore.ts'
+import { isCacheValid } from '../../core/cache/isCacheValid.ts'
 import { logger } from '../../core/utils/logger.ts'
+import type { AiFileNote } from '../../core/types/ai-note.ts'
 
 const DEFAULT_LLM_THRESHOLD = 0.4
 
-export async function runGenerate(args: { root?: string }): Promise<void> {
+export async function runGenerate(args: { root?: string; force?: boolean }): Promise<void> {
   const root = path.resolve(args.root ?? process.cwd())
   const config = await loadConfig(root)
 
@@ -44,12 +50,26 @@ export async function runGenerate(args: { root?: string }): Promise<void> {
     logger.info(`LLM synthesis enabled (provider: ${llmConfig!.provider}, threshold: ${llmThreshold})`)
   }
 
-  // 5. Generate and write notes
+  // 5. Load cache
+  const hashStore = args.force ? new Map() : await loadCache(root)
+  if (args.force) logger.info('Cache bypassed (--force)')
+
+  // 6. Generate and write notes
   logger.info('Writing notes...')
   let written = 0
+  let skipped = 0
   let synthesized = 0
+  const notes: AiFileNote[] = []
 
   for (const analysis of analyses) {
+    const file = files.find((f) => f.path === analysis.filePath)!
+
+    // Check cache
+    if (!args.force && await isCacheValid(analysis.filePath, file.relativePath, hashStore)) {
+      skipped++
+      continue
+    }
+
     const relatedTests = findRelatedTests(analysis.filePath, files)
     const gitSignals = getGitSignals(analysis.filePath, root)
 
@@ -60,10 +80,8 @@ export async function runGenerate(args: { root?: string }): Promise<void> {
     }
     const tests = { filePath: analysis.filePath, relatedTests }
 
-    // Build static note first
     let note = buildBasicNote(analysis, graph, tests, gitSignals)
 
-    // LLM synthesis for critical files
     if (provider && note.criticalityScore >= llmThreshold) {
       note = await synthesizeFileNote(
         { analysis, graph, tests, git: gitSignals, staticNote: note },
@@ -75,9 +93,22 @@ export async function runGenerate(args: { root?: string }): Promise<void> {
 
     await writeJsonNote(note, root, config.output)
     await writeMarkdownNote(note, root, config.output)
+
+    // Update cache
+    const hash = await computeHash(analysis.filePath)
+    hashStore.set(file.relativePath, hash)
+
+    notes.push(note)
     written++
   }
 
+  // 7. Save cache
+  await saveCache(root, hashStore)
+
+  // 8. Build and write index
+  await writeIndexNote(buildIndex(notes, root), root, config.output)
+
   logger.success(`Generated ${written} notes in ${config.output}/`)
+  if (skipped > 0) logger.info(`Skipped ${skipped} unchanged files (use --force to reprocess)`)
   if (provider) logger.info(`LLM synthesized: ${synthesized} files`)
 }

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -1,0 +1,134 @@
+import path from 'node:path'
+import fs from 'node:fs'
+import { loadConfig } from '../../core/config/loadConfig.ts'
+import { scanRepository } from '../../core/scanner/scanRepository.ts'
+import { parseFile } from '../../core/ast/parseFile.ts'
+import { buildDependencyGraph } from '../../core/graph/buildDependencyGraph.ts'
+import { buildReverseDependencyGraph } from '../../core/graph/buildReverseDependencyGraph.ts'
+import { findRelatedTests } from '../../core/tests/findRelatedTests.ts'
+import { getGitSignals } from '../../core/git/getGitSignals.ts'
+import { buildBasicNote } from '../../core/output/buildBasicNote.ts'
+import { writeJsonNote } from '../../core/output/writeJsonNote.ts'
+import { writeMarkdownNote } from '../../core/output/writeMarkdownNote.ts'
+import { createProvider } from '../../core/llm/provider/factory.ts'
+import { synthesizeFileNote } from '../../core/llm/synthesizeFileNote.ts'
+import { computeHash } from '../../core/cache/computeHash.ts'
+import { loadCache, saveCache } from '../../core/cache/cacheStore.ts'
+import { buildIndex } from '../../core/output/buildIndex.ts'
+import { writeIndexNote } from '../../core/output/writeIndexNote.ts'
+import { logger } from '../../core/utils/logger.ts'
+import type { AiFileNote } from '../../core/types/ai-note.ts'
+
+const DEFAULT_LLM_THRESHOLD = 0.4
+const DEBOUNCE_MS = 300
+
+export async function runWatch(args: { root?: string }): Promise<void> {
+  const root = path.resolve(args.root ?? process.cwd())
+  const config = await loadConfig(root)
+
+  logger.info(`Watching ${root} for changes... (Ctrl+C to stop)`)
+
+  // Initial full generate to build graphs and cache
+  const files = await scanRepository(config)
+  const analyses = files.map((f) => parseFile(f.path))
+  const depGraph = buildDependencyGraph(analyses, root)
+  const revGraph = buildReverseDependencyGraph(depGraph)
+
+  const llmConfig = config.llm
+  const provider = llmConfig ? createProvider(llmConfig) : null
+  const llmThreshold = llmConfig?.llmThreshold ?? DEFAULT_LLM_THRESHOLD
+  const temperature = llmConfig?.temperature ?? 0.2
+
+  const hashStore = await loadCache(root)
+  const noteMap = new Map<string, AiFileNote>()
+
+  // Generate initial notes
+  for (const analysis of analyses) {
+    const note = await processFile(analysis.filePath, root, config.output, files, depGraph, revGraph, provider, llmThreshold, temperature)
+    if (note) {
+      noteMap.set(analysis.filePath, note)
+      const relPath = path.relative(root, analysis.filePath)
+      hashStore.set(relPath, await computeHash(analysis.filePath))
+    }
+  }
+
+  await saveCache(root, hashStore)
+  await writeIndexNote(buildIndex([...noteMap.values()], root), root, config.output)
+  logger.success(`Initial generation complete. Watching for changes...`)
+
+  // Debounce map
+  const pending = new Map<string, ReturnType<typeof setTimeout>>()
+
+  const watcher = fs.watch(root, { recursive: true }, (_, filename) => {
+    if (!filename) return
+    if (!filename.endsWith('.ts') && !filename.endsWith('.tsx')) return
+    if (config.exclude.some((p) => filename.includes(p.replace('/**', '').replace('**/', '')))) return
+
+    const existing = pending.get(filename)
+    if (existing) clearTimeout(existing)
+
+    pending.set(filename, setTimeout(async () => {
+      pending.delete(filename)
+      const absolutePath = path.resolve(root, filename)
+
+      logger.info(`Changed: ${filename}`)
+
+      const note = await processFile(absolutePath, root, config.output, files, depGraph, revGraph, provider, llmThreshold, temperature)
+      if (note) {
+        noteMap.set(absolutePath, note)
+        hashStore.set(filename, await computeHash(absolutePath))
+        await saveCache(root, hashStore)
+        await writeIndexNote(buildIndex([...noteMap.values()], root), root, config.output)
+        logger.success(`Regenerated: ${filename}`)
+      }
+    }, DEBOUNCE_MS))
+  })
+
+  process.on('SIGINT', () => {
+    watcher.close()
+    logger.info('Watch stopped.')
+    process.exit(0)
+  })
+}
+
+async function processFile(
+  filePath: string,
+  root: string,
+  outputDir: string,
+  files: Awaited<ReturnType<typeof scanRepository>>,
+  depGraph: Map<string, string[]>,
+  revGraph: Map<string, string[]>,
+  provider: ReturnType<typeof createProvider> | null,
+  llmThreshold: number,
+  temperature: number,
+): Promise<AiFileNote | null> {
+  try {
+    const analysis = parseFile(filePath)
+    const relatedTests = findRelatedTests(filePath, files)
+    const gitSignals = getGitSignals(filePath, root)
+
+    const graph = {
+      filePath,
+      directDependencies: depGraph.get(filePath) ?? [],
+      reverseDependencies: revGraph.get(filePath) ?? [],
+    }
+    const tests = { filePath, relatedTests }
+
+    let note = buildBasicNote(analysis, graph, tests, gitSignals)
+
+    if (provider && note.criticalityScore >= llmThreshold) {
+      note = await synthesizeFileNote(
+        { analysis, graph, tests, git: gitSignals, staticNote: note },
+        provider,
+        temperature,
+      )
+    }
+
+    await writeJsonNote(note, root, outputDir)
+    await writeMarkdownNote(note, root, outputDir)
+    return note
+  } catch (err) {
+    logger.warn(`Failed to process ${filePath}: ${(err as Error).message}`)
+    return null
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 import { parseArgs } from 'node:util'
 import { runScan } from './commands/scan.ts'
 import { runGenerate } from './commands/generate.ts'
+import { runWatch } from './commands/watch.ts'
 
 const [, , command, ...rest] = process.argv
 
@@ -9,6 +10,7 @@ const { values } = parseArgs({
   args: rest,
   options: {
     root: { type: 'string', short: 'r' },
+    force: { type: 'boolean', short: 'f' },
   },
   strict: false,
 })
@@ -19,7 +21,11 @@ switch (command) {
     break
 
   case 'generate':
-    await runGenerate({ root: values.root })
+    await runGenerate({ root: values.root, force: values.force })
+    break
+
+  case 'watch':
+    await runWatch({ root: values.root })
     break
 
   default:
@@ -32,9 +38,11 @@ Usage:
 Commands:
   scan      Discover and list eligible files
   generate  Analyze files and write .ai-notes/ sidecars
+  watch     Watch for changes and regenerate notes incrementally
 
 Options:
   --root, -r <path>   Root directory to analyze (default: cwd)
+  --force, -f         Bypass cache and reprocess all files (generate only)
 `)
     process.exit(command ? 1 : 0)
 }

--- a/src/core/cache/cacheStore.ts
+++ b/src/core/cache/cacheStore.ts
@@ -1,0 +1,28 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
+
+const CACHE_FILE = 'hashes.json'
+
+export type HashStore = Map<string, string>
+
+export async function loadCache(root: string): Promise<HashStore> {
+  const cachePath = getCachePath(root)
+  try {
+    const raw = await fs.readFile(cachePath, 'utf-8')
+    const obj = JSON.parse(raw) as Record<string, string>
+    return new Map(Object.entries(obj))
+  } catch {
+    return new Map()
+  }
+}
+
+export async function saveCache(root: string, store: HashStore): Promise<void> {
+  const cachePath = getCachePath(root)
+  await fs.mkdir(path.dirname(cachePath), { recursive: true })
+  const obj = Object.fromEntries(store)
+  await fs.writeFile(cachePath, JSON.stringify(obj, null, 2), 'utf-8')
+}
+
+function getCachePath(root: string): string {
+  return path.resolve(root, 'cache', CACHE_FILE)
+}

--- a/src/core/cache/computeHash.ts
+++ b/src/core/cache/computeHash.ts
@@ -1,0 +1,6 @@
+export async function computeHash(filePath: string): Promise<string> {
+  const buffer = await Bun.file(filePath).arrayBuffer()
+  const hashBuffer = await crypto.subtle.digest('SHA-1', buffer)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+}

--- a/src/core/cache/isCacheValid.ts
+++ b/src/core/cache/isCacheValid.ts
@@ -1,0 +1,13 @@
+import type { HashStore } from './cacheStore.ts'
+import { computeHash } from './computeHash.ts'
+
+export async function isCacheValid(
+  filePath: string,
+  relativePath: string,
+  store: HashStore,
+): Promise<boolean> {
+  const stored = store.get(relativePath)
+  if (!stored) return false
+  const current = await computeHash(filePath)
+  return current === stored
+}

--- a/src/core/output/buildIndex.ts
+++ b/src/core/output/buildIndex.ts
@@ -1,0 +1,40 @@
+import path from 'node:path'
+import type { AiFileNote } from '../types/ai-note.ts'
+
+export type IndexEntry = {
+  filePath: string
+  relativePath: string
+  criticalityScore: number
+  model: string
+  purpose: string
+  generatedAt: string
+}
+
+export type NoteIndex = {
+  generatedAt: string
+  totalFiles: number
+  synthesizedFiles: number
+  entries: IndexEntry[]
+}
+
+export function buildIndex(notes: AiFileNote[], root: string): NoteIndex {
+  const entries: IndexEntry[] = notes
+    .map((note) => ({
+      filePath: note.filePath,
+      relativePath: path.relative(root, note.filePath),
+      criticalityScore: note.criticalityScore,
+      model: note.model,
+      purpose: note.purpose.observed[0] ?? note.purpose.inferred[0] ?? '',
+      generatedAt: note.generatedAt,
+    }))
+    .sort((a, b) => b.criticalityScore - a.criticalityScore)
+
+  const synthesizedFiles = notes.filter((n) => n.model !== 'static').length
+
+  return {
+    generatedAt: new Date().toISOString(),
+    totalFiles: notes.length,
+    synthesizedFiles,
+    entries,
+  }
+}

--- a/src/core/output/writeIndexNote.ts
+++ b/src/core/output/writeIndexNote.ts
@@ -1,0 +1,45 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import type { NoteIndex } from './buildIndex.ts'
+
+export async function writeIndexNote(index: NoteIndex, root: string, outputDir: string): Promise<void> {
+  const base = path.resolve(root, outputDir)
+  await fs.mkdir(base, { recursive: true })
+
+  await fs.writeFile(
+    path.join(base, 'index.json'),
+    JSON.stringify(index, null, 2),
+    'utf-8',
+  )
+
+  await fs.writeFile(
+    path.join(base, 'index.md'),
+    renderIndexMarkdown(index),
+    'utf-8',
+  )
+}
+
+function renderIndexMarkdown(index: NoteIndex): string {
+  const date = new Date(index.generatedAt).toISOString().slice(0, 10)
+
+  const lines = [
+    `# AI Notes Index`,
+    ``,
+    `**Generated:** ${date} | **Total files:** ${index.totalFiles} | **LLM synthesized:** ${index.synthesizedFiles}`,
+    ``,
+    `## Files by Criticality`,
+    ``,
+    `| Score | File | Model | Purpose |`,
+    `|-------|------|-------|---------|`,
+  ]
+
+  for (const entry of index.entries) {
+    const score = entry.criticalityScore.toFixed(2)
+    const link = `[${entry.relativePath}](./${entry.relativePath}.md)`
+    const purpose = entry.purpose.replace(/\|/g, '\\|').slice(0, 80)
+    lines.push(`| ${score} | ${link} | ${entry.model} | ${purpose} |`)
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}

--- a/tests/cache/cacheStore.test.ts
+++ b/tests/cache/cacheStore.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'bun:test'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { loadCache, saveCache } from '../../src/core/cache/cacheStore.ts'
+import { computeHash } from '../../src/core/cache/computeHash.ts'
+import { isCacheValid } from '../../src/core/cache/isCacheValid.ts'
+
+const TMP_ROOT = path.resolve(import.meta.dir, '../../.tmp-test-cache')
+
+afterEach(async () => {
+  await fs.rm(TMP_ROOT, { recursive: true, force: true })
+})
+
+describe('loadCache', () => {
+  it('returns empty map when no cache file exists', async () => {
+    const store = await loadCache(TMP_ROOT)
+    expect(store.size).toBe(0)
+  })
+})
+
+describe('saveCache / loadCache round-trip', () => {
+  it('persists and restores hash store', async () => {
+    const store = new Map([
+      ['src/foo.ts', 'abc123'],
+      ['src/bar.ts', 'def456'],
+    ])
+    await saveCache(TMP_ROOT, store)
+    const loaded = await loadCache(TMP_ROOT)
+    expect(loaded.get('src/foo.ts')).toBe('abc123')
+    expect(loaded.get('src/bar.ts')).toBe('def456')
+  })
+})
+
+describe('computeHash', () => {
+  it('returns a hex string for a real file', async () => {
+    const filePath = path.resolve(import.meta.dir, '../../src/core/types/ai-note.ts')
+    const hash = await computeHash(filePath)
+    expect(typeof hash).toBe('string')
+    expect(hash.length).toBe(40) // SHA-1 = 40 hex chars
+    expect(/^[0-9a-f]+$/.test(hash)).toBe(true)
+  })
+
+  it('produces the same hash for unchanged file', async () => {
+    const filePath = path.resolve(import.meta.dir, '../../src/core/types/ai-note.ts')
+    const h1 = await computeHash(filePath)
+    const h2 = await computeHash(filePath)
+    expect(h1).toBe(h2)
+  })
+})
+
+describe('isCacheValid', () => {
+  it('returns false when file not in cache', async () => {
+    const store = new Map<string, string>()
+    const filePath = path.resolve(import.meta.dir, '../../src/core/types/ai-note.ts')
+    const valid = await isCacheValid(filePath, 'src/core/types/ai-note.ts', store)
+    expect(valid).toBe(false)
+  })
+
+  it('returns true when hash matches', async () => {
+    const filePath = path.resolve(import.meta.dir, '../../src/core/types/ai-note.ts')
+    const hash = await computeHash(filePath)
+    const store = new Map([['src/core/types/ai-note.ts', hash]])
+    const valid = await isCacheValid(filePath, 'src/core/types/ai-note.ts', store)
+    expect(valid).toBe(true)
+  })
+
+  it('returns false when hash differs', async () => {
+    const filePath = path.resolve(import.meta.dir, '../../src/core/types/ai-note.ts')
+    const store = new Map([['src/core/types/ai-note.ts', 'outdatedhash']])
+    const valid = await isCacheValid(filePath, 'src/core/types/ai-note.ts', store)
+    expect(valid).toBe(false)
+  })
+})

--- a/tests/output/buildIndex.test.ts
+++ b/tests/output/buildIndex.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from 'bun:test'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { buildIndex } from '../../src/core/output/buildIndex.ts'
+import { writeIndexNote } from '../../src/core/output/writeIndexNote.ts'
+import type { AiFileNote } from '../../src/core/types/ai-note.ts'
+
+const TMP_OUTPUT = path.resolve(import.meta.dir, '../../.tmp-test-index')
+const ROOT = '/project'
+
+afterEach(async () => {
+  await fs.rm(TMP_OUTPUT, { recursive: true, force: true })
+})
+
+function makeNote(filePath: string, score: number, model = 'static'): AiFileNote {
+  const empty = { observed: [], inferred: [], confidence: 0, evidence: [] }
+  return {
+    filePath,
+    purpose: { observed: ['Does something'], inferred: [], confidence: 0.6, evidence: [] },
+    invariants: empty,
+    sensitiveDependencies: empty,
+    importantDecisions: empty,
+    knownPitfalls: empty,
+    impactValidation: empty,
+    criticalityScore: score,
+    generatedAt: new Date().toISOString(),
+    model,
+  }
+}
+
+describe('buildIndex', () => {
+  it('sorts entries by criticalityScore descending', () => {
+    const notes = [
+      makeNote('/project/src/a.ts', 0.3),
+      makeNote('/project/src/b.ts', 0.8),
+      makeNote('/project/src/c.ts', 0.5),
+    ]
+    const index = buildIndex(notes, ROOT)
+    expect(index.entries[0].criticalityScore).toBe(0.8)
+    expect(index.entries[1].criticalityScore).toBe(0.5)
+    expect(index.entries[2].criticalityScore).toBe(0.3)
+  })
+
+  it('counts synthesized files correctly', () => {
+    const notes = [
+      makeNote('/project/src/a.ts', 0.3, 'static'),
+      makeNote('/project/src/b.ts', 0.8, 'llama3'),
+      makeNote('/project/src/c.ts', 0.5, 'claude-sonnet-4-6'),
+    ]
+    const index = buildIndex(notes, ROOT)
+    expect(index.synthesizedFiles).toBe(2)
+    expect(index.totalFiles).toBe(3)
+  })
+
+  it('sets relativePath relative to root', () => {
+    const notes = [makeNote('/project/src/utils/helper.ts', 0.4)]
+    const index = buildIndex(notes, ROOT)
+    expect(index.entries[0].relativePath).toBe('src/utils/helper.ts')
+  })
+})
+
+describe('writeIndexNote', () => {
+  it('creates index.json and index.md', async () => {
+    const notes = [makeNote('/project/src/a.ts', 0.7)]
+    const index = buildIndex(notes, ROOT)
+    await writeIndexNote(index, ROOT, TMP_OUTPUT)
+
+    const jsonExists = await fs.access(path.join(TMP_OUTPUT, 'index.json')).then(() => true).catch(() => false)
+    const mdExists = await fs.access(path.join(TMP_OUTPUT, 'index.md')).then(() => true).catch(() => false)
+    expect(jsonExists).toBe(true)
+    expect(mdExists).toBe(true)
+  })
+
+  it('index.md contains the file entry', async () => {
+    const notes = [makeNote('/project/src/a.ts', 0.7)]
+    const index = buildIndex(notes, ROOT)
+    await writeIndexNote(index, ROOT, TMP_OUTPUT)
+    const content = await fs.readFile(path.join(TMP_OUTPUT, 'index.md'), 'utf-8')
+    expect(content).toContain('src/a.ts')
+    expect(content).toContain('0.70')
+  })
+})


### PR DESCRIPTION
## Contexto

Fase 4 — última fase do braito. Torna a ferramenta operacional para uso contínuo com cache incremental, visão consolidada do repositório, watch mode e automação no CI.

---

## 1. Cache por hash — `src/core/cache/`

Evita reprocessar arquivos não alterados entre execuções.

| Arquivo | Responsabilidade |
|---|---|
| `computeHash.ts` | SHA-1 do conteúdo do arquivo via `crypto.subtle.digest` nativo do Bun |
| `cacheStore.ts` | Persiste `Map<relativePath, hash>` em `cache/hashes.json` |
| `isCacheValid.ts` | Compara hash atual com o armazenado — retorna `true` se arquivo não mudou |

**Comportamento em `generate`:**
- Segunda rodada pula arquivos sem mudança → log `"Skipped X unchanged files"`
- `--force` / `-f` ignora cache e reprocessa tudo
- Hash atualizado no cache após cada arquivo processado com sucesso

---

## 2. Índice por criticidade — `src/core/output/`

Visão consolidada de todos os arquivos analisados.

| Arquivo | Responsabilidade |
|---|---|
| `buildIndex.ts` | Agrega `AiFileNote[]`, ordena por `criticalityScore` desc, conta sintetizados |
| `writeIndexNote.ts` | Grava `.ai-notes/index.json` e `.ai-notes/index.md` |

**`index.json`:**
```json
{
  "generatedAt": "...",
  "totalFiles": 42,
  "synthesizedFiles": 12,
  "entries": [{ "filePath": "...", "relativePath": "...", "criticalityScore": 0.81, "model": "llama3", "purpose": "..." }]
}
```

**`index.md`:** tabela Markdown rankeada com link para o `.md` de cada arquivo.

---

## 3. Watch mode — `src/cli/commands/watch.ts`

```bash
bun src/cli/index.ts watch --root ./
```

- `fs.watch` nativo com debounce de 300ms por arquivo
- Ao detectar mudança em `.ts`/`.tsx`: roda pipeline completo no arquivo alterado
- Atualiza `cache/hashes.json` e `index.json`/`index.md` a cada regeneração
- Ctrl+C para parada limpa

---

## 4. CI integration — `.github/workflows/ai-notes.yml`

- Trigger: push para `main`/`master` quando arquivos de código mudam
- `fetch-depth: 0` para histórico Git completo (necessário para git signals)
- Suporte a `ANTHROPIC_API_KEY` e `OPENAI_API_KEY` como secrets
- Auto-commit com `[skip ci]` para evitar loop

---

## CLI atualizado

```
Commands:
  scan      Discover and list eligible files
  generate  Analyze files and write .ai-notes/ sidecars
  watch     Watch for changes and regenerate notes incrementally

Options:
  --root, -r   Root directory (default: cwd)
  --force, -f  Bypass cache and reprocess all files (generate only)
```

---

## Testes — 2 novas suítes

| Arquivo | Cobertura |
|---|---|
| `tests/cache/cacheStore.test.ts` | `loadCache` vazio, round-trip save/load, SHA-1 hex format + determinismo, `isCacheValid` true/false/missing |
| `tests/output/buildIndex.test.ts` | Ordenação por score, contagem de sintetizados, relativePath, criação de index.json e index.md |

---

## Como verificar

```bash
bun install

# Primeira rodada — processa tudo
bun src/cli/index.ts generate --root ./

# Segunda rodada — pula arquivos não alterados
bun src/cli/index.ts generate --root ./
# → "Skipped X unchanged files"

# Forçar reprocessamento
bun src/cli/index.ts generate --root ./ --force

# Ver índice
cat .ai-notes/index.md

# Watch mode
bun src/cli/index.ts watch --root ./
# editar qualquer .ts e ver nota regenerada automaticamente

bun test
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)