### PR TITLE
docs: add CHANGELOG, TODO and project conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to braito will be documented here.
+
+## [Unreleased]
+
+## [1.0.0] — 2026-03-29
+
+### Added
+- **Phase 1 — Scanner**: File discovery with `Bun.Glob`, include/exclude/ignore rules (`src/core/scanner/`)
+- **Phase 2 — Static Analyzer**: `ts-morph` based AST extractors for imports, exports, symbols, hooks, comments (TODO/FIXME/HACK), env vars, API calls (`src/core/ast/`)
+- **Phase 2 — Graph Engine**: Direct + reverse dependency graphs; `resolveImportPath` handles relative paths and `tsconfig.paths` aliases (`src/core/graph/`)
+- **Phase 2 — Git Intelligence**: Churn score, recent commit messages, co-changed files, author count via `git` CLI + `Bun.spawnSync` (`src/core/git/`)
+- **Phase 3 — Cache**: SHA-1 hash per file, `cache/hashes.json`, skip unchanged files between runs (`src/core/cache/`)
+- **Phase 3 — LLM Layer**: Provider abstraction for `ollama`, `anthropic`, `openai`; prompt builder, Zod schema validation, merge strategy (`src/core/llm/`)
+- **Phase 4 — Output**: `buildBasicNote`, `writeJsonNote`, `writeMarkdownNote`, `buildIndex`, `writeIndexNote` (`src/core/output/`)
+- **CLI**: Commands `scan`, `generate` (with `--force`), `watch` (`src/cli/`)
+- **CI**: GitHub Actions workflow `.github/workflows/ai-notes.yml`
+- **Domain model**: `AiFileNote` with `observed`/`inferred` split per `StructuredListField`
+- **Test suites**: Full test coverage via `bun test`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,3 +125,11 @@ Do not edit `.ai-notes/` or `cache/` manually.
 - Add the entry under `[Unreleased]` with the appropriate category (`Added`, `Changed`, `Fixed`, `Removed`)
 - When a TODO item is completed, check it off in `TODO.md` and add the corresponding entry to `CHANGELOG.md`
 - Use the format: `- **Feature name** — brief description of what was done`
+
+## Git Conventions
+
+**Never include "claude" in commit messages or branch names.**
+
+- Do not sign commits with "claude", "Claude", or any AI assistant identifier
+- Do not prefix branch names with `claude/` — use descriptive names based on the feature or fix (e.g. `feat/alias-resolution`, `fix/incremental-graph`)
+- Commit messages must reflect the work done, not who or what did it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,32 +113,15 @@ Do not edit `.ai-notes/` or `cache/` manually.
 
 ---
 
-## Next Steps
+## Project Tracking
 
-### Short-term improvements
+- **`TODO.md`** — pending next steps, grouped by short/medium/long-term
+- **`CHANGELOG.md`** — record of all completed work
 
-**Alias resolution** — `resolveImportPath.ts` currently reads `tsconfig.paths` but does not handle bundler aliases (Vite, Webpack, Metro). Needed for accurate graphs in monorepos with custom path mappings.
+## Changelog Rule
 
-**Incremental graph rebuild** — currently the full dependency graph is rebuilt on every run even when using cache. In watch mode this is fine, but for large repos a partial rebuild (only affected files + their consumers) would be faster.
+**Every time a feature, fix, or improvement is completed, update `CHANGELOG.md` immediately.**
 
-**`--filter` flag** — allow `generate --filter packages/search/**` to scope the pipeline to a subdirectory or domain without changing config.
-
-**Confidence calibration** — the heuristic `criticalityScore` thresholds were set conservatively. After running against real monorepos, these weights should be tuned based on observed false positives/negatives.
-
-### Medium-term features
-
-**Markdown output for `invariants` and `importantDecisions`** — these fields are currently only filled by LLM. A heuristic pre-fill pass (pattern matching in comments, ADR files, changelog) would improve coverage even without LLM.
-
-**Domain grouping** — group files by folder/package in `index.md`, not just a flat ranked list. Useful for monorepos where each package has its own criticality context.
-
-**Stale note detection** — flag notes whose `generatedAt` is older than N days or whose source file has changed since last synthesis, prompting re-synthesis.
-
-**Test coverage hints** — integrate with coverage reports (lcov, c8) to surface actual uncovered files in `impactValidation`, not just heuristic test discovery.
-
-### Long-term / Phase 5 candidates
-
-**Multi-language support** — the AST layer was designed to be modular per language (`core/ast/analyzers/`). Adding Python (via tree-sitter) or Go support follows the same extractor pattern.
-
-**MCP server** — expose braito as a Model Context Protocol server so AI assistants (Cursor, Claude) can query notes about specific files on demand during code review.
-
-**Interactive UI** — a `bun src/cli/index.ts ui` command serving a local web interface to browse the index, filter by domain/score, and trigger re-synthesis.
+- Add the entry under `[Unreleased]` with the appropriate category (`Added`, `Changed`, `Fixed`, `Removed`)
+- When a TODO item is completed, check it off in `TODO.md` and add the corresponding entry to `CHANGELOG.md`
+- Use the format: `- **Feature name** — brief description of what was done`

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,37 @@
+# TODO
+
+Tracked next steps for braito. Move items to CHANGELOG.md when completed.
+
+---
+
+## Short-term
+
+- [ ] **Alias resolution** — `resolveImportPath.ts` reads `tsconfig.paths` but does not handle bundler aliases (Vite, Webpack, Metro). Needed for accurate graphs in monorepos with custom path mappings.
+
+- [ ] **Incremental graph rebuild** — full dependency graph is rebuilt on every run even when using cache. In watch mode this is fine, but for large repos a partial rebuild (only affected files + their consumers) would be faster.
+
+- [ ] **`--filter` flag** — allow `generate --filter packages/search/**` to scope the pipeline to a subdirectory or domain without changing config.
+
+- [ ] **Confidence calibration** — heuristic `criticalityScore` thresholds were set conservatively. After running against real monorepos, tune weights based on observed false positives/negatives.
+
+---
+
+## Medium-term
+
+- [ ] **Heuristic pre-fill for `invariants` and `importantDecisions`** — these fields are currently only filled by LLM. A pattern matching pass (comments, ADR files, changelog) would improve coverage even without LLM.
+
+- [ ] **Domain grouping in `index.md`** — group files by folder/package instead of a flat ranked list. Useful for monorepos where each package has its own criticality context.
+
+- [ ] **Stale note detection** — flag notes whose `generatedAt` is older than N days or whose source file has changed since last synthesis, prompting re-synthesis.
+
+- [ ] **Test coverage hints** — integrate with coverage reports (lcov, c8) to surface actual uncovered files in `impactValidation`, not just heuristic test discovery.
+
+---
+
+## Long-term / Phase 5
+
+- [ ] **Multi-language support** — AST layer is modular per language (`core/ast/analyzers/`). Adding Python (via tree-sitter) or Go follows the same extractor pattern.
+
+- [ ] **MCP server** — expose braito as a Model Context Protocol server so AI assistants (Cursor, Claude) can query notes about specific files on demand during code review.
+
+- [ ] **Interactive UI** — `bun src/cli/index.ts ui` command serving a local web interface to browse the index, filter by domain/score, and trigger re-synthesis.


### PR DESCRIPTION
## Summary

- Criado `CHANGELOG.md` com todas as 4 fases implementadas registradas como `v1.0.0`
- Criado `TODO.md` com os próximos passos organizados em short/medium/long-term com checkboxes
- Atualizado `CLAUDE.md`: removida seção "Next Steps", adicionadas regras de changelog e convenções de git (sem "claude" em commits ou branches)