### PR TITLE
feat: structured logger with debug/verbose/silent CLI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to braito will be documented here.
 ## [Unreleased]
 
 ### Added
+- **Logger upgrade** — replaced simple logger with a structured `Logger` class supporting `debug`, `info`, `warn`, `error`, `silent` levels; `--debug` flag enables debug-level output with timestamps; `--verbose` / `-v` enables debug without timestamps; `--silent` suppresses all output except errors; `logger.debug()` calls added throughout `generate`, `scan`, and `watch` commands for per-file cache hits, graph stats, LLM decisions, and alias counts; 16 tests added (`tests/utils/logger.test.ts`)
 - **`--filter` flag** — `generate --filter <glob>` scopes note generation to a subdirectory without changing config; full graph is still built from all files for accurate dependency signals (`src/cli/commands/generate.ts`)
 - **Heuristic pre-fill for `invariants` and `importantDecisions`** — `extractComments` now captures `INVARIANT/CONTRACT/ASSERT` and `NOTE/DECISION/WHY/REASON` comment patterns; `buildBasicNote` uses them plus structural signals (validation libs, env vars, hooks rules, decision-flavoured commit messages) to populate both fields without LLM
 - **Domain grouping in `index.md`** — `buildIndex` now derives a `domain` per entry (first dir segment, or `packages/<name>` for monorepo roots); `renderIndexMarkdown` renders one section per domain sorted by max criticality, each with file count and avg score

--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ bun src/cli/index.ts generate --root ./ --force
 # Scope to a subdirectory
 bun src/cli/index.ts generate --root ./ --filter src/core/**
 
+# Debug mode — verbose output with per-file details and timestamps
+bun src/cli/index.ts generate --root ./ --debug
+
+# Verbose — same as debug but without timestamps
+bun src/cli/index.ts generate --root ./ --verbose
+
+# Silent — suppress all output except errors
+bun src/cli/index.ts generate --root ./ --silent
+
 # Watch mode — regenerates on file change
 bun src/cli/index.ts watch --root ./
 

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Tracked next steps for braito. Move items to CHANGELOG.md when completed.
 
 - [x] **Confidence calibration** — heuristic `criticalityScore` thresholds were set conservatively. After running against real monorepos, tune weights based on observed false positives/negatives.
 
-- [ ] **Logger upgrade** ⭐ — replace the current simple logger with a structured logger supporting log levels (`debug`, `info`, `warn`, `error`), optional timestamps, and a `--debug` / `--verbose` CLI flag; improves diagnosability across all commands.
+- [x] **Logger upgrade** ⭐ — replace the current simple logger with a structured logger supporting log levels (`debug`, `info`, `warn`, `error`), optional timestamps, and a `--debug` / `--verbose` CLI flag; improves diagnosability across all commands.
 
 - [ ] **Temperature bug fix** — `provider/anthropic.ts` and `provider/openai.ts` ignore the user's `temperature` config; fix both providers to respect `llmConfig.temperature`.
 

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -33,6 +33,7 @@ export async function runGenerate(args: {
   const config = await loadConfig(root)
 
   logger.info(`Generating notes for ${root}`)
+  logger.debug(`Config: llm=${config.llm?.provider ?? 'none'}, output=${config.output}, staleThreshold=${config.staleThresholdDays}d`)
 
   // 1. Scan
   const files = await scanRepository(config)
@@ -62,7 +63,9 @@ export async function runGenerate(args: {
       // File unchanged and note is current — reuse cached AST analysis
       analyses.push(cachedAnalysis)
       analysisHits++
+      logger.debug(`Cache hit: ${file.relativePath}`)
     } else {
+      logger.debug(`Parsing: ${file.relativePath}`)
       const analysis = parseFile(file.path)
       analyses.push(analysis)
       analysisStore.set(file.relativePath, analysis)
@@ -78,8 +81,10 @@ export async function runGenerate(args: {
   //    Aliases are loaded from tsconfig.json paths + bundler configs (Vite, Webpack, Metro).
   logger.info('Building dependency graph...')
   const aliases = loadBundlerAliases(root)
+  logger.debug(`Bundler aliases loaded: ${Object.keys(aliases).length} entries`)
   const depGraph = buildDependencyGraph(analyses, root, aliases)
   const revGraph = buildReverseDependencyGraph(depGraph)
+  logger.debug(`Dependency graph: ${depGraph.size} nodes`)
 
   // 6. Load coverage report (optional — lcov.info or coverage-summary.json)
   const coverageMap = loadCoverage(root)
@@ -134,8 +139,10 @@ export async function runGenerate(args: {
     const tests = { filePath: analysis.filePath, relatedTests, coveragePct }
 
     let note = buildBasicNote(analysis, graph, tests, gitSignals)
+    logger.debug(`${file.relativePath}: score=${note.criticalityScore.toFixed(2)}, deps=${graph.directDependencies.length}, consumers=${graph.reverseDependencies.length}`)
 
     if (provider && note.criticalityScore >= llmThreshold) {
+      logger.debug(`LLM synthesizing: ${file.relativePath} (score=${note.criticalityScore.toFixed(2)})`)
       note = await synthesizeFileNote(
         { analysis, graph, tests, git: gitSignals, staticNote: note },
         provider,

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -9,6 +9,8 @@ export async function runScan(args: { root?: string }): Promise<void> {
   const files = await scanRepository(config)
 
   logger.info(`Scanning ${root}`)
+  logger.debug(`Include patterns: ${config.include.join(', ')}`)
+  logger.debug(`Exclude patterns: ${config.exclude.join(', ')}`)
   logger.info(`Found ${files.length} files\n`)
 
   for (const file of files) {

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -31,10 +31,13 @@ export async function runWatch(args: { root?: string }): Promise<void> {
 
   // Initial full generate to build graphs and cache
   const files = await scanRepository(config)
+  logger.debug(`Found ${files.length} files to watch`)
   const analyses = files.map((f) => parseFile(f.path))
   const aliases = loadBundlerAliases(root)
+  logger.debug(`Bundler aliases: ${Object.keys(aliases).length} entries`)
   const depGraph = buildDependencyGraph(analyses, root, aliases)
   let revGraph = buildReverseDependencyGraph(depGraph)
+  logger.debug(`Dependency graph: ${depGraph.size} nodes`)
 
   const llmConfig = config.llm
   const provider = llmConfig ? createProvider(llmConfig) : null
@@ -80,6 +83,7 @@ export async function runWatch(args: { root?: string }): Promise<void> {
       const changedAnalysis = parseFile(absolutePath)
       updateDependencyGraph(depGraph, changedAnalysis, root, aliases)
       revGraph = buildReverseDependencyGraph(depGraph)
+      logger.debug(`Graph updated incrementally for: ${filename}`)
 
       const note = await processFile(absolutePath, root, config.output, files, depGraph, revGraph, provider, llmThreshold, temperature)
       if (note) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { parseArgs } from 'node:util'
+import { logger } from '../core/utils/logger.ts'
 import { runScan } from './commands/scan.ts'
 import { runGenerate } from './commands/generate.ts'
 import { runWatch } from './commands/watch.ts'
@@ -11,12 +12,25 @@ const [, , command, ...rest] = process.argv
 const { values } = parseArgs({
   args: rest,
   options: {
-    root: { type: 'string', short: 'r' },
-    force: { type: 'boolean', short: 'f' },
-    filter: { type: 'string' },
+    root:    { type: 'string',  short: 'r' },
+    force:   { type: 'boolean', short: 'f' },
+    filter:  { type: 'string' },
+    debug:   { type: 'boolean' },
+    silent:  { type: 'boolean' },
+    verbose: { type: 'boolean', short: 'v' },
   },
   strict: false,
 })
+
+// Configure log level from flags (debug > verbose > silent > default)
+if (values.debug) {
+  logger.setLevel('debug')
+  logger.enableTimestamps()
+} else if (values.verbose) {
+  logger.setLevel('debug')
+} else if (values.silent) {
+  logger.setLevel('error')
+}
 
 switch (command) {
   case 'scan':
@@ -59,6 +73,9 @@ Options:
   --root, -r <path>      Root directory to analyze (default: cwd)
   --force, -f            Bypass cache and reprocess all files (generate only)
   --filter <glob>        Scope generation to files matching a glob pattern (generate only)
+  --debug                Enable debug-level logging with timestamps
+  --verbose, -v          Enable verbose logging (same as --debug, no timestamps)
+  --silent               Suppress all output except errors
 `)
     process.exit(command ? 1 : 0)
 }

--- a/src/core/utils/logger.ts
+++ b/src/core/utils/logger.ts
@@ -1,6 +1,95 @@
-export const logger = {
-  info: (msg: string) => console.log(`[braito] ${msg}`),
-  success: (msg: string) => console.log(`[braito] ✓ ${msg}`),
-  warn: (msg: string) => console.warn(`[braito] ⚠ ${msg}`),
-  error: (msg: string) => console.error(`[braito] ✗ ${msg}`),
+/**
+ * Structured logger with configurable log levels.
+ *
+ * Levels (ascending severity): debug < info < warn < error
+ * Messages below the active level are silenced.
+ *
+ * Configure via:
+ *   logger.setLevel('debug')   // programmatic
+ *   --debug CLI flag           // sets level to 'debug'
+ *   --silent CLI flag          // sets level to 'error' (suppress info/warn)
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'
+
+const LEVELS: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  silent: 4,
 }
+
+const isTTY = process.stdout.isTTY ?? false
+
+const COLORS = {
+  debug: '\x1b[36m',   // cyan
+  info:  '\x1b[34m',   // blue
+  warn:  '\x1b[33m',   // yellow
+  error: '\x1b[31m',   // red
+  reset: '\x1b[0m',
+  dim:   '\x1b[2m',
+  green: '\x1b[32m',
+}
+
+function colorize(color: string, text: string): string {
+  return isTTY ? `${color}${text}${COLORS.reset}` : text
+}
+
+function timestamp(): string {
+  return new Date().toISOString().slice(11, 23) // HH:mm:ss.mmm
+}
+
+class Logger {
+  private level: LogLevel = 'info'
+  private showTimestamps = false
+
+  setLevel(level: LogLevel): void {
+    this.level = level
+  }
+
+  getLevel(): LogLevel {
+    return this.level
+  }
+
+  enableTimestamps(): void {
+    this.showTimestamps = true
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return LEVELS[level] >= LEVELS[this.level]
+  }
+
+  private prefix(level: LogLevel): string {
+    const ts = this.showTimestamps ? colorize(COLORS.dim, `${timestamp()} `) : ''
+    const tag = colorize(COLORS.dim, '[braito]')
+    return `${ts}${tag}`
+  }
+
+  debug(msg: string): void {
+    if (!this.shouldLog('debug')) return
+    console.log(`${this.prefix('debug')} ${colorize(COLORS.debug, 'dbg')} ${msg}`)
+  }
+
+  info(msg: string): void {
+    if (!this.shouldLog('info')) return
+    console.log(`${this.prefix('info')} ${msg}`)
+  }
+
+  success(msg: string): void {
+    if (!this.shouldLog('info')) return
+    console.log(`${this.prefix('info')} ${colorize(COLORS.green, '✓')} ${msg}`)
+  }
+
+  warn(msg: string): void {
+    if (!this.shouldLog('warn')) return
+    console.warn(`${this.prefix('warn')} ${colorize(COLORS.warn, '⚠')} ${msg}`)
+  }
+
+  error(msg: string): void {
+    if (!this.shouldLog('error')) return
+    console.error(`${this.prefix('error')} ${colorize(COLORS.error, '✗')} ${msg}`)
+  }
+}
+
+export const logger = new Logger()

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, spyOn } from 'bun:test'
+import { logger } from '../../src/core/utils/logger.ts'
+
+describe('Logger', () => {
+  beforeEach(() => {
+    // Reset to default state before each test
+    logger.setLevel('info')
+  })
+
+  describe('setLevel / getLevel', () => {
+    it('defaults to info', () => {
+      expect(logger.getLevel()).toBe('info')
+    })
+
+    it('updates level via setLevel', () => {
+      logger.setLevel('debug')
+      expect(logger.getLevel()).toBe('debug')
+      logger.setLevel('info')
+    })
+
+    it('accepts all valid levels', () => {
+      for (const level of ['debug', 'info', 'warn', 'error', 'silent'] as const) {
+        logger.setLevel(level)
+        expect(logger.getLevel()).toBe(level)
+      }
+    })
+  })
+
+  describe('log filtering', () => {
+    it('suppresses debug when level is info', () => {
+      logger.setLevel('info')
+      const spy = spyOn(console, 'log').mockImplementation(() => {})
+      logger.debug('should not appear')
+      expect(spy.mock.calls.length).toBe(0)
+      spy.mockRestore()
+    })
+
+    it('emits debug when level is debug', () => {
+      logger.setLevel('debug')
+      const spy = spyOn(console, 'log').mockImplementation(() => {})
+      logger.debug('should appear')
+      expect(spy.mock.calls.length).toBe(1)
+      spy.mockRestore()
+    })
+
+    it('suppresses info when level is error', () => {
+      logger.setLevel('error')
+      const spy = spyOn(console, 'log').mockImplementation(() => {})
+      logger.info('should not appear')
+      expect(spy.mock.calls.length).toBe(0)
+      spy.mockRestore()
+    })
+
+    it('suppresses warn when level is error', () => {
+      logger.setLevel('error')
+      const spy = spyOn(console, 'warn').mockImplementation(() => {})
+      logger.warn('should not appear')
+      expect(spy.mock.calls.length).toBe(0)
+      spy.mockRestore()
+    })
+
+    it('emits error at any level except silent', () => {
+      for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+        logger.setLevel(level)
+        const spy = spyOn(console, 'error').mockImplementation(() => {})
+        logger.error('should appear')
+        expect(spy.mock.calls.length).toBe(1)
+        spy.mockRestore()
+      }
+    })
+
+    it('suppresses all output at silent level', () => {
+      logger.setLevel('silent')
+      const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+      logger.debug('x')
+      logger.info('x')
+      logger.warn('x')
+      logger.error('x')
+      expect(logSpy.mock.calls.length).toBe(0)
+      expect(warnSpy.mock.calls.length).toBe(0)
+      expect(errorSpy.mock.calls.length).toBe(0)
+      logSpy.mockRestore()
+      warnSpy.mockRestore()
+      errorSpy.mockRestore()
+    })
+  })
+
+  describe('output methods', () => {
+    beforeEach(() => { logger.setLevel('debug') })
+
+    it('info writes to console.log', () => {
+      const spy = spyOn(console, 'log').mockImplementation(() => {})
+      logger.info('hello')
+      expect(spy.mock.calls.length).toBe(1)
+      spy.mockRestore()
+    })
+
+    it('success writes to console.log', () => {
+      const spy = spyOn(console, 'log').mockImplementation(() => {})
+      logger.success('done')
+      expect(spy.mock.calls.length).toBe(1)
+      spy.mockRestore()
+    })
+
+    it('warn writes to console.warn', () => {
+      const spy = spyOn(console, 'warn').mockImplementation(() => {})
+      logger.warn('caution')
+      expect(spy.mock.calls.length).toBe(1)
+      spy.mockRestore()
+    })
+
+    it('error writes to console.error', () => {
+      const spy = spyOn(console, 'error').mockImplementation(() => {})
+      logger.error('oops')
+      expect(spy.mock.calls.length).toBe(1)
+      spy.mockRestore()
+    })
+
+    it('debug writes to console.log', () => {
+      const spy = spyOn(console, 'log').mockImplementation(() => {})
+      logger.debug('trace')
+      expect(spy.mock.calls.length).toBe(1)
+      spy.mockRestore()
+    })
+
+    it('log output includes the message text', () => {
+      const spy = spyOn(console, 'log').mockImplementation(() => {})
+      logger.info('my unique message')
+      const output = spy.mock.calls[0][0] as string
+      expect(output).toContain('my unique message')
+      spy.mockRestore()
+    })
+  })
+
+  describe('enableTimestamps', () => {
+    it('does not throw when called', () => {
+      expect(() => logger.enableTimestamps()).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Replace simple console logger with a structured `Logger` class supporting configurable levels (`debug < info < warn < error < silent`)
- Add `--debug`, `--verbose` / `-v`, and `--silent` CLI flags to all commands
- Add `logger.debug()` instrumentation throughout `generate`, `scan`, and `watch` for cache hits, graph stats, alias counts, and per-file criticality scores
- 16 tests added in `tests/utils/logger.test.ts`

## Test plan

- [ ] `bun test tests/utils/logger.test.ts` — all 16 tests pass
- [ ] `bun src/cli/index.ts generate --root ./ --debug` — shows debug-level output with timestamps
- [ ] `bun src/cli/index.ts generate --root ./ --verbose` — shows debug-level output without timestamps
- [ ] `bun src/cli/index.ts generate --root ./ --silent` — no output except errors
- [ ] `bun src/cli/index.ts scan --root ./ --debug` — shows include/exclude patterns