### PR TITLE
fix: Go local import detection using go.mod module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to braito will be documented here.
 - **Interactive UI** — `bun src/cli/index.ts ui` serves a local web interface at port 7842; browse notes grouped by domain, filter by score, search by filename, view all fields per file
 
 ### Fixed
+- **Go local import detection** — replaced the incorrect `includes('./')` heuristic with `go.mod`-based module path matching; `getGoModuleName` walks up the directory tree to find the nearest `go.mod` and classifies imports starting with the module prefix as local; falls back to `./`/`../` heuristics when no `go.mod` is found
 - **Alias resolution in watch mode** — `watch.ts` now calls `loadBundlerAliases(root)` and passes aliases to `buildDependencyGraph`, matching the behavior of `generate.ts`; bundler aliases (Vite, Webpack, Metro) are now resolved correctly in watch mode
 - **Incremental graph rebuild in watch mode** — `watch.ts` now calls `updateDependencyGraph` (new export) on each file change instead of rebuilding the full graph; only the changed file's dependency entry is updated, then the reverse graph is rebuilt from the patched dep graph
 - **Graph test using real temp files** — `buildDependencyGraph.test.ts` now creates actual temp files so `resolveImportPath` can resolve them via `fs.existsSync`; added coverage for `updateDependencyGraph`

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@ Tracked next steps for braito. Move items to CHANGELOG.md when completed.
 
 - [ ] **Dynamic import detection** — `extractImports.ts` misses `import('./path')` — add regex-based detection so lazy-loaded dependencies appear in the graph.
 
-- [ ] **Go local import detection fix** — the current heuristic (`includes('./')`) is incorrect for Go; use module-relative path matching based on the package declaration or `go.mod`.
+- [x] **Go local import detection fix** — the current heuristic (`includes('./')`) is incorrect for Go; use module-relative path matching based on the package declaration or `go.mod`.
 
 ---
 

--- a/src/core/ast/analyzers/go/goAnalyzer.ts
+++ b/src/core/ast/analyzers/go/goAnalyzer.ts
@@ -1,5 +1,33 @@
+import path from 'node:path'
+import fs from 'node:fs'
 import type { LanguageAnalyzer } from '../../types.ts'
 import type { StaticFileAnalysis } from '../../../types/file-analysis.ts'
+
+/**
+ * Walk up the directory tree from filePath to find the nearest go.mod file.
+ * Returns the module name declared in "module <name>" or null if not found.
+ */
+export function getGoModuleName(filePath: string): string | null {
+  let dir = path.dirname(path.resolve(filePath))
+  const root = path.parse(dir).root
+
+  while (dir !== root) {
+    const goModPath = path.join(dir, 'go.mod')
+    if (fs.existsSync(goModPath)) {
+      try {
+        const content = fs.readFileSync(goModPath, 'utf8')
+        const match = content.match(/^module\s+(\S+)/m)
+        if (match) return match[1]
+      } catch {
+        // ignore read errors
+      }
+    }
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return null
+}
 
 export const goAnalyzer: LanguageAnalyzer = {
   extensions: ['.go'],
@@ -7,8 +35,8 @@ export const goAnalyzer: LanguageAnalyzer = {
     return {
       filePath,
       imports: extractImports(content),
-      localImports: extractLocalImports(content),
-      externalImports: extractExternalImports(content),
+      localImports: extractLocalImports(filePath, content),
+      externalImports: extractExternalImports(filePath, content),
       exports: extractExports(content),
       symbols: extractSymbols(content),
       hooks: [],
@@ -32,14 +60,25 @@ function extractImports(content: string): string[] {
   return [...new Set(imports)]
 }
 
-function extractLocalImports(content: string): string[] {
-  // Go local imports typically contain the module path prefix (e.g. "github.com/user/repo/internal/...")
-  // Heuristic: imports with relative-looking paths (containing '.' but not a domain)
-  return extractImports(content).filter((i) => i.includes('./') || i.startsWith('.'))
+function extractLocalImports(filePath: string, content: string): string[] {
+  // Go local imports use module-relative paths (e.g. "github.com/org/repo/pkg/util").
+  // Look up go.mod to get the module name and match against it.
+  // Fall back to ./ and ../ heuristics if go.mod is not found.
+  const moduleName = getGoModuleName(filePath)
+  const allImports = extractImports(content)
+  if (moduleName) {
+    return allImports.filter((imp) => imp.startsWith(moduleName + '/') || imp === moduleName)
+  }
+  return allImports.filter((imp) => imp.startsWith('./') || imp.startsWith('../'))
 }
 
-function extractExternalImports(content: string): string[] {
-  return extractImports(content).filter((i) => !i.startsWith('.'))
+function extractExternalImports(filePath: string, content: string): string[] {
+  const moduleName = getGoModuleName(filePath)
+  const allImports = extractImports(content)
+  if (moduleName) {
+    return allImports.filter((imp) => !imp.startsWith(moduleName + '/') && imp !== moduleName)
+  }
+  return allImports.filter((imp) => !imp.startsWith('./') && !imp.startsWith('../'))
 }
 
 function extractExports(content: string): string[] {

--- a/tests/ast/goAnalyzer.test.ts
+++ b/tests/ast/goAnalyzer.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'bun:test'
-import { goAnalyzer } from '../../src/core/ast/analyzers/go/goAnalyzer.ts'
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import path from 'node:path'
+import fs from 'node:fs'
+import os from 'node:os'
+import { goAnalyzer, getGoModuleName } from '../../src/core/ast/analyzers/go/goAnalyzer.ts'
 
 const SAMPLE = `
 package main
@@ -26,6 +29,22 @@ func FetchData(url string) (*http.Response, error) {
 func privateHelper() {}
 
 var BaseURL = "https://example.com"
+`.trim()
+
+// Sample with module-relative imports
+const SAMPLE_WITH_LOCAL = `
+package server
+
+import (
+    "fmt"
+    "github.com/org/myrepo/internal/config"
+    "github.com/org/myrepo/pkg/util"
+    "github.com/third-party/library"
+)
+
+func Start() {
+    fmt.Println("starting")
+}
 `.trim()
 
 describe('goAnalyzer', () => {
@@ -73,5 +92,90 @@ describe('goAnalyzer', () => {
   it('captures NOTE as decision comment', () => {
     const result = goAnalyzer.analyze('/project/main.go', SAMPLE)
     expect(result.comments.decision.some((d) => d.includes('net/http'))).toBe(true)
+  })
+})
+
+describe('goAnalyzer — go.mod module-relative import detection', () => {
+  let tmpDir: string
+  let goFile: string
+
+  beforeAll(() => {
+    // Create a temp directory with a go.mod file
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'braito-go-test-'))
+    fs.writeFileSync(
+      path.join(tmpDir, 'go.mod'),
+      'module github.com/org/myrepo\n\ngo 1.21\n',
+      'utf8',
+    )
+    const subDir = path.join(tmpDir, 'cmd', 'server')
+    fs.mkdirSync(subDir, { recursive: true })
+    goFile = path.join(subDir, 'main.go')
+    fs.writeFileSync(goFile, SAMPLE_WITH_LOCAL, 'utf8')
+  })
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('getGoModuleName finds go.mod walking up from a nested file', () => {
+    const name = getGoModuleName(goFile)
+    expect(name).toBe('github.com/org/myrepo')
+  })
+
+  it('classifies module-relative imports as local', () => {
+    const result = goAnalyzer.analyze(goFile, SAMPLE_WITH_LOCAL)
+    expect(result.localImports).toContain('github.com/org/myrepo/internal/config')
+    expect(result.localImports).toContain('github.com/org/myrepo/pkg/util')
+  })
+
+  it('does not classify third-party imports as local', () => {
+    const result = goAnalyzer.analyze(goFile, SAMPLE_WITH_LOCAL)
+    expect(result.localImports).not.toContain('github.com/third-party/library')
+    expect(result.localImports).not.toContain('fmt')
+  })
+
+  it('classifies third-party and stdlib imports as external', () => {
+    const result = goAnalyzer.analyze(goFile, SAMPLE_WITH_LOCAL)
+    expect(result.externalImports).toContain('github.com/third-party/library')
+    expect(result.externalImports).toContain('fmt')
+  })
+
+  it('does not classify local imports as external', () => {
+    const result = goAnalyzer.analyze(goFile, SAMPLE_WITH_LOCAL)
+    expect(result.externalImports).not.toContain('github.com/org/myrepo/internal/config')
+    expect(result.externalImports).not.toContain('github.com/org/myrepo/pkg/util')
+  })
+})
+
+describe('goAnalyzer — fallback when no go.mod present', () => {
+  it('getGoModuleName returns null when no go.mod is found', () => {
+    // Use a path that definitely won't have go.mod above it (temp dir with no go.mod)
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'braito-no-gomod-'))
+    try {
+      const result = getGoModuleName(path.join(tmpDir, 'main.go'))
+      expect(result).toBeNull()
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to ./ and ../ heuristics without go.mod', () => {
+    // Provide a fake path with no go.mod anywhere
+    const fakePath = '/tmp/braito-no-gomod-fallback-xyz/pkg/main.go'
+    const content = `
+package pkg
+
+import (
+    "./local"
+    "../sibling"
+    "fmt"
+    "github.com/external/lib"
+)
+`.trim()
+    const result = goAnalyzer.analyze(fakePath, content)
+    expect(result.localImports).toContain('./local')
+    expect(result.localImports).toContain('../sibling')
+    expect(result.externalImports).toContain('fmt')
+    expect(result.externalImports).toContain('github.com/external/lib')
   })
 })


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The previous `includes('./')` heuristic never matched real Go imports, which use module-relative paths like `"github.com/org/repo/pkg/util"`
- Added `getGoModuleName()` helper that walks up the directory tree to find the nearest `go.mod` and parses the `module <name>` declaration
- Imports starting with the module prefix are classified as local; all others are external; falls back to `./`/`../` matching when no `go.mod` is found

## Test plan

- [ ] `bun test tests/ast/goAnalyzer.test.ts` passes all 16 tests
- [ ] Module-relative local imports are correctly detected with a real `go.mod` fixture
- [ ] Third-party imports are not classified as local
- [ ] Fallback to `./`/`../` works when no `go.mod` is present
- [ ] `getGoModuleName` returns `null` when no `go.mod` is found walking up the tree

https://claude.ai/code/session_01AGToc4kS7e8vmi41geuYxH
EOF
)