### PR TITLE
feat: configurable LLM synthesis timeout with static note fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cache/hashes.json
 coverage/
 *.env
 .env*
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to braito will be documented here.
 ## [Unreleased]
 
 ### Added
+- **LLM synthesis timeout** — `synthesizeFileNote` accepts a `timeoutMs` parameter (default 30 000 ms); `Promise.race` races the provider call against a timeout reject, falling back to the static note automatically via the existing catch block; configurable via `llm.timeoutMs` in `ai-notes.config.ts`; `LLMConfig` type and `llmConfigSchema` updated accordingly
 - **Config validation** — `loadConfig` now validates `ai-notes.config.ts` with a Zod schema (`src/core/config/configSchema.ts`); invalid values (unknown provider, out-of-range threshold/temperature, empty output dir, non-positive staleThresholdDays) emit a clear error with field paths instead of silently falling back to defaults; 15 tests added (`tests/config/configSchema.test.ts`)
 - **Temperature bug fix** — confirmed `provider/anthropic.ts` and `provider/openai.ts` correctly pass `request.temperature` through the `LLMRequest` type; marked resolved
 - **Logger upgrade** — replaced simple logger with a structured `Logger` class supporting `debug`, `info`, `warn`, `error`, `silent` levels; `--debug` flag enables debug-level output with timestamps; `--verbose` / `-v` enables debug without timestamps; `--silent` suppresses all output except errors; `logger.debug()` calls added throughout `generate`, `scan`, and `watch` commands for per-file cache hits, graph stats, LLM decisions, and alias counts; 16 tests added (`tests/utils/logger.test.ts`)

--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,7 @@ Tracked next steps for braito. Move items to CHANGELOG.md when completed.
 
 - [x] **Config validation** — validate `ai-notes.config.ts` with Zod on load; emit clear errors for unknown keys or invalid values instead of silently falling back to defaults.
 
-- [ ] **LLM synthesis timeout** — add a configurable per-file timeout (default 30s) to `synthesizeFileNote`; fall back to static note on timeout instead of hanging indefinitely.
+- [x] **LLM synthesis timeout** — add a configurable per-file timeout (default 30s) to `synthesizeFileNote`; fall back to static note on timeout instead of hanging indefinitely.
 
 - [ ] **Dynamic import detection** — `extractImports.ts` misses `import('./path')` — add regex-based detection so lazy-loaded dependencies appear in the graph.
 

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -105,6 +105,7 @@ export async function runGenerate(args: {
   const provider = llmConfig ? createProvider(llmConfig) : null
   const llmThreshold = llmConfig?.llmThreshold ?? DEFAULT_LLM_THRESHOLD
   const temperature = llmConfig?.temperature ?? 0.2
+  const timeoutMs = llmConfig?.timeoutMs ?? 30_000
 
   if (provider) {
     logger.info(`LLM synthesis enabled (provider: ${llmConfig!.provider}, threshold: ${llmThreshold})`)
@@ -147,6 +148,7 @@ export async function runGenerate(args: {
         { analysis, graph, tests, git: gitSignals, staticNote: note },
         provider,
         temperature,
+        timeoutMs,
       )
       synthesized++
     }

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -43,13 +43,14 @@ export async function runWatch(args: { root?: string }): Promise<void> {
   const provider = llmConfig ? createProvider(llmConfig) : null
   const llmThreshold = llmConfig?.llmThreshold ?? DEFAULT_LLM_THRESHOLD
   const temperature = llmConfig?.temperature ?? 0.2
+  const timeoutMs = llmConfig?.timeoutMs ?? 30_000
 
   const hashStore = await loadCache(root)
   const noteMap = new Map<string, AiFileNote>()
 
   // Generate initial notes
   for (const analysis of analyses) {
-    const note = await processFile(analysis.filePath, root, config.output, files, depGraph, revGraph, provider, llmThreshold, temperature)
+    const note = await processFile(analysis.filePath, root, config.output, files, depGraph, revGraph, provider, llmThreshold, temperature, timeoutMs)
     if (note) {
       noteMap.set(analysis.filePath, note)
       const relPath = path.relative(root, analysis.filePath)
@@ -85,7 +86,7 @@ export async function runWatch(args: { root?: string }): Promise<void> {
       revGraph = buildReverseDependencyGraph(depGraph)
       logger.debug(`Graph updated incrementally for: ${filename}`)
 
-      const note = await processFile(absolutePath, root, config.output, files, depGraph, revGraph, provider, llmThreshold, temperature)
+      const note = await processFile(absolutePath, root, config.output, files, depGraph, revGraph, provider, llmThreshold, temperature, timeoutMs)
       if (note) {
         noteMap.set(absolutePath, note)
         hashStore.set(filename, await computeHash(absolutePath))

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -114,6 +114,7 @@ async function processFile(
   provider: ReturnType<typeof createProvider> | null,
   llmThreshold: number,
   temperature: number,
+  timeoutMs: number,
 ): Promise<AiFileNote | null> {
   try {
     const analysis = parseFile(filePath)
@@ -134,6 +135,7 @@ async function processFile(
         { analysis, graph, tests, git: gitSignals, staticNote: note },
         provider,
         temperature,
+        timeoutMs,
       )
     }
 

--- a/src/core/config/configSchema.ts
+++ b/src/core/config/configSchema.ts
@@ -17,6 +17,7 @@ export const llmConfigSchema = z.object({
     .min(0, 'llm.temperature must be >= 0')
     .max(2, 'llm.temperature must be <= 2')
     .optional(),
+  timeoutMs: z.number().int().positive().optional(),
 })
 
 export const aiNotesConfigSchema = z.object({

--- a/src/core/llm/synthesizeFileNote.ts
+++ b/src/core/llm/synthesizeFileNote.ts
@@ -9,16 +9,23 @@ export async function synthesizeFileNote(
   ctx: PromptContext,
   provider: LLMProvider,
   temperature: number = 0.2,
+  timeoutMs: number = 30_000,
 ): Promise<AiFileNote> {
   const staticNote = ctx.staticNote
 
   try {
     const userPrompt = buildPrompt(ctx)
-    const response = await provider.complete({
-      system: SYSTEM_PROMPT,
-      user: userPrompt,
-      temperature,
-    })
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`LLM synthesis timed out after ${timeoutMs}ms`)), timeoutMs)
+    )
+    const response = await Promise.race([
+      provider.complete({
+        system: SYSTEM_PROMPT,
+        user: userPrompt,
+        temperature,
+      }),
+      timeoutPromise,
+    ])
 
     const parsed = parseJSON(response.content)
     const validated = llmNoteSchema.safeParse(parsed)

--- a/src/core/types/project.ts
+++ b/src/core/types/project.ts
@@ -14,6 +14,7 @@ export type LLMConfig = {
   apiKey?: string
   llmThreshold?: number
   temperature?: number
+  timeoutMs?: number
 }
 
 export type AiNotesConfig = {

--- a/tests/llm/synthesizeTimeout.test.ts
+++ b/tests/llm/synthesizeTimeout.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'bun:test'
+import { synthesizeFileNote } from '../../src/core/llm/synthesizeFileNote.ts'
+import type { LLMProvider } from '../../src/core/llm/provider/types.ts'
+import type { StaticFileAnalysis, GraphSignals, TestSignals, GitSignals } from '../../src/core/types/file-analysis.ts'
+import type { AiFileNote } from '../../src/core/types/ai-note.ts'
+
+function makeStaticNote(overrides: Partial<AiFileNote> = {}): AiFileNote {
+  const empty = { observed: [], inferred: [], confidence: 0, evidence: [] }
+  return {
+    filePath: '/project/src/useSearch.ts',
+    purpose: { observed: ['Exports hooks: useSearch'], inferred: [], confidence: 0.6, evidence: [] },
+    invariants: empty,
+    sensitiveDependencies: empty,
+    importantDecisions: empty,
+    knownPitfalls: empty,
+    impactValidation: empty,
+    criticalityScore: 0.5,
+    generatedAt: new Date().toISOString(),
+    model: 'static',
+    ...overrides,
+  }
+}
+
+function makeCtx(staticNote: AiFileNote) {
+  const analysis: StaticFileAnalysis = {
+    filePath: staticNote.filePath,
+    imports: [], localImports: [], externalImports: [],
+    exports: ['useSearch'], symbols: ['useSearch'], hooks: ['useSearch'],
+    envVars: [], apiCalls: [],
+    comments: { todo: [], fixme: [], hack: [] },
+    hasSideEffects: false,
+  }
+  const graph: GraphSignals = { filePath: staticNote.filePath, directDependencies: [], reverseDependencies: [] }
+  const tests: TestSignals = { filePath: staticNote.filePath, relatedTests: [] }
+  const git: GitSignals = { filePath: staticNote.filePath, churnScore: 0, recentCommitMessages: [], coChangedFiles: [], authorCount: 0 }
+  return { analysis, graph, tests, git, staticNote }
+}
+
+describe('synthesizeFileNote — timeout', () => {
+  it('falls back to static note when provider exceeds timeoutMs', async () => {
+    // Provider that never resolves within the timeout window
+    const slowProvider: LLMProvider = {
+      complete: () => new Promise<never>(() => { /* never resolves */ }),
+    }
+
+    const staticNote = makeStaticNote()
+    const result = await synthesizeFileNote(makeCtx(staticNote), slowProvider, 0.2, 50)
+
+    expect(result.model).toBe('static')
+    expect(result).toEqual(staticNote)
+  }, 5000)
+
+  it('falls back to static note and preserves all fields on timeout', async () => {
+    const slowProvider: LLMProvider = {
+      complete: () => new Promise<never>(() => { /* never resolves */ }),
+    }
+
+    const staticNote = makeStaticNote({
+      criticalityScore: 0.9,
+      purpose: { observed: ['Critical path handler'], inferred: [], confidence: 0.8, evidence: [] },
+    })
+    const result = await synthesizeFileNote(makeCtx(staticNote), slowProvider, 0.2, 50)
+
+    expect(result.model).toBe('static')
+    expect(result.criticalityScore).toBe(0.9)
+    expect(result.purpose.observed).toContain('Critical path handler')
+    expect(result.purpose.inferred).toHaveLength(0)
+  }, 5000)
+
+  it('completes successfully when provider responds before timeout', async () => {
+    const validResponse = JSON.stringify({
+      purpose: { observed: [], inferred: ['Fast response'], confidence: 0.9, evidence: [] },
+      invariants: { observed: [], inferred: [], confidence: 0, evidence: [] },
+      sensitiveDependencies: { observed: [], inferred: [], confidence: 0, evidence: [] },
+      importantDecisions: { observed: [], inferred: [], confidence: 0, evidence: [] },
+      knownPitfalls: { observed: [], inferred: [], confidence: 0, evidence: [] },
+      impactValidation: { observed: [], inferred: [], confidence: 0, evidence: [] },
+    })
+
+    const fastProvider: LLMProvider = {
+      complete: async () => ({ content: validResponse, model: 'fast-model' }),
+    }
+
+    const staticNote = makeStaticNote()
+    // Use a generous timeout — provider responds immediately
+    const result = await synthesizeFileNote(makeCtx(staticNote), fastProvider, 0.2, 5000)
+
+    expect(result.model).toBe('fast-model')
+    expect(result.purpose.inferred).toContain('Fast response')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a `timeoutMs` parameter (default `30_000` ms) to `synthesizeFileNote` — the provider call is raced against a `setTimeout` reject via `Promise.race`, so a hung LLM call no longer blocks the pipeline indefinitely
- On timeout the existing `catch` block returns the static note, keeping fallback behaviour consistent with other LLM errors
- `timeoutMs` is configurable via `llm.timeoutMs` in `ai-notes.config.ts`; `LLMConfig` type and `llmConfigSchema` (Zod) updated to include the new optional field
- `generate.ts` and `watch.ts` both read `config.llm?.timeoutMs ?? 30_000` and forward it to `synthesizeFileNote`

## Changed files

- `src/core/llm/synthesizeFileNote.ts` — new `timeoutMs` param + `Promise.race` wrapper
- `src/cli/commands/generate.ts` — reads `timeoutMs` from config, passes it through
- `src/cli/commands/watch.ts` — same; `processFile` signature extended with `timeoutMs`
- `src/core/types/project.ts` — `timeoutMs?: number` added to `LLMConfig`
- `src/core/config/configSchema.ts` — `timeoutMs: z.number().int().positive().optional()` added to `llmConfigSchema`
- `tests/llm/synthesizeTimeout.test.ts` — 3 new tests: slow provider triggers timeout fallback, field preservation on timeout, fast provider completes normally

## Test plan

- [ ] `bun test tests/llm/synthesizeTimeout.test.ts` — all 3 tests pass
- [ ] Set `llm.timeoutMs: 1` in config and run `generate` against a live LLM — should fall back to static notes immediately with a timeout warning in the log
- [ ] Omit `timeoutMs` from config — default 30 s applies

https://claude.ai/code/session_01AGToc4kS7e8vmi41geuYxH