### PR TITLE
fix: parseFile returns empty analysis on syntax errors instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to braito will be documented here.
 
 ### Fixed
 - **Go local import detection** — replaced the incorrect `includes('./')` heuristic with `go.mod`-based module path matching; `getGoModuleName` walks up the directory tree to find the nearest `go.mod` and classifies imports starting with the module prefix as local; falls back to `./`/`../` heuristics when no `go.mod` is found
+- **`parseFile` error resilience** — wrapped ts-morph parsing in try/catch in `parseFile`; on any error a warning is logged via `logger.warn` and an empty `StaticFileAnalysis` is returned instead of crashing the pipeline
 - **Alias resolution in watch mode** — `watch.ts` now calls `loadBundlerAliases(root)` and passes aliases to `buildDependencyGraph`, matching the behavior of `generate.ts`; bundler aliases (Vite, Webpack, Metro) are now resolved correctly in watch mode
 - **Incremental graph rebuild in watch mode** — `watch.ts` now calls `updateDependencyGraph` (new export) on each file change instead of rebuilding the full graph; only the changed file's dependency entry is updated, then the reverse graph is rebuilt from the patched dep graph
 - **Graph test using real temp files** — `buildDependencyGraph.test.ts` now creates actual temp files so `resolveImportPath` can resolve them via `fs.existsSync`; added coverage for `updateDependencyGraph`

--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@ Tracked next steps for braito. Move items to CHANGELOG.md when completed.
 
 - [ ] **`scan --format json`** — add `--format json|table` flag to the `scan` command for machine-readable output and integration with external tools.
 
-- [ ] **`parseFile` error resilience** — wrap ts-morph parsing in try/catch; emit a warning and return an empty analysis instead of crashing on files with syntax errors.
+- [x] **`parseFile` error resilience** — wrap ts-morph parsing in try/catch; emit a warning and return an empty analysis instead of crashing on files with syntax errors.
 
 ---
 

--- a/src/core/ast/parseFile.ts
+++ b/src/core/ast/parseFile.ts
@@ -8,55 +8,61 @@ import { extractSymbols } from './analyzers/ts/extractSymbols.ts'
 import { extractHooks } from './analyzers/ts/extractHooks.ts'
 import { extractComments } from './analyzers/ts/extractComments.ts'
 import { getAnalyzer } from './analyzerRegistry.ts'
+import { logger } from '../utils/logger.ts'
 
 const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false })
 
 const TS_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.mjs'])
 
 export function parseFile(filePath: string): StaticFileAnalysis {
-  const ext = path.extname(filePath)
+  try {
+    const ext = path.extname(filePath)
 
-  // Delegate to language-specific analyzer if available
-  const analyzer = getAnalyzer(ext)
-  if (analyzer) {
-    const content = fs.readFileSync(filePath, 'utf-8')
-    return analyzer.analyze(filePath, content)
-  }
+    // Delegate to language-specific analyzer if available
+    const analyzer = getAnalyzer(ext)
+    if (analyzer) {
+      const content = fs.readFileSync(filePath, 'utf-8')
+      return analyzer.analyze(filePath, content)
+    }
 
-  // Default: TypeScript/JavaScript via ts-morph
-  if (!TS_EXTENSIONS.has(ext)) {
-    // Unknown extension — return empty analysis rather than crashing
+    // Default: TypeScript/JavaScript via ts-morph
+    if (!TS_EXTENSIONS.has(ext)) {
+      // Unknown extension — return empty analysis rather than crashing
+      return emptyAnalysis(filePath)
+    }
+
+    let sourceFile = project.getSourceFile(filePath)
+    if (!sourceFile) {
+      sourceFile = project.addSourceFileAtPath(filePath)
+    }
+
+    const imports = extractImports(sourceFile)
+    const exports = extractExports(sourceFile)
+    const symbols = extractSymbols(sourceFile)
+    const hooks = extractHooks(sourceFile)
+    const comments = extractComments(sourceFile)
+
+    const hasSideEffects =
+      imports.external.some((s) =>
+        ['analytics', 'sentry', 'datadog', 'mixpanel', 'firebase'].some((kw) => s.includes(kw)),
+      ) || comments.hack.length > 0
+
+    return {
+      filePath,
+      imports: imports.all,
+      localImports: imports.local,
+      externalImports: imports.external,
+      exports,
+      symbols,
+      hooks,
+      envVars: extractEnvVars(sourceFile.getFullText()),
+      apiCalls: extractApiCalls(sourceFile.getFullText()),
+      comments,
+      hasSideEffects,
+    }
+  } catch (err) {
+    logger.warn(`Failed to parse ${filePath}: ${(err as Error).message}`)
     return emptyAnalysis(filePath)
-  }
-
-  let sourceFile = project.getSourceFile(filePath)
-  if (!sourceFile) {
-    sourceFile = project.addSourceFileAtPath(filePath)
-  }
-
-  const imports = extractImports(sourceFile)
-  const exports = extractExports(sourceFile)
-  const symbols = extractSymbols(sourceFile)
-  const hooks = extractHooks(sourceFile)
-  const comments = extractComments(sourceFile)
-
-  const hasSideEffects =
-    imports.external.some((s) =>
-      ['analytics', 'sentry', 'datadog', 'mixpanel', 'firebase'].some((kw) => s.includes(kw)),
-    ) || comments.hack.length > 0
-
-  return {
-    filePath,
-    imports: imports.all,
-    localImports: imports.local,
-    externalImports: imports.external,
-    exports,
-    symbols,
-    hooks,
-    envVars: extractEnvVars(sourceFile.getFullText()),
-    apiCalls: extractApiCalls(sourceFile.getFullText()),
-    comments,
-    hasSideEffects,
   }
 }
 

--- a/tests/ast/parseFileResilience.test.ts
+++ b/tests/ast/parseFileResilience.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach, spyOn } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { parseFile } from '../../src/core/ast/parseFile.ts'
+import * as extractImportsModule from '../../src/core/ast/analyzers/ts/extractImports.ts'
+
+describe('parseFile error resilience', () => {
+  const tempFiles: string[] = []
+
+  function createTempFile(content: string, ext = '.ts'): string {
+    const filePath = path.join(os.tmpdir(), `braito-test-${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`)
+    fs.writeFileSync(filePath, content, 'utf-8')
+    tempFiles.push(filePath)
+    return filePath
+  }
+
+  afterEach(() => {
+    for (const f of tempFiles.splice(0)) {
+      try { fs.unlinkSync(f) } catch { /* ignore */ }
+    }
+  })
+
+  it('returns empty analysis when an extractor throws instead of crashing', () => {
+    const filePath = createTempFile('export const x = 1')
+
+    // Force an error inside the ts-morph pipeline by making an extractor throw
+    const spy = spyOn(extractImportsModule, 'extractImports').mockImplementation(() => {
+      throw new Error('Simulated extractor failure')
+    })
+
+    let result: ReturnType<typeof parseFile>
+    try {
+      result = parseFile(filePath)
+    } finally {
+      spy.mockRestore()
+    }
+
+    expect(result!).toBeDefined()
+    expect(result!.filePath).toBe(filePath)
+    expect(result!.imports).toEqual([])
+    expect(result!.exports).toEqual([])
+    expect(result!.symbols).toEqual([])
+  })
+
+  it('sets filePath correctly on the returned empty analysis when an error occurs', () => {
+    const filePath = createTempFile('export const y = 2')
+
+    const spy = spyOn(extractImportsModule, 'extractImports').mockImplementation(() => {
+      throw new Error('Simulated failure')
+    })
+
+    let result: ReturnType<typeof parseFile>
+    try {
+      result = parseFile(filePath)
+    } finally {
+      spy.mockRestore()
+    }
+
+    expect(result!.filePath).toBe(filePath)
+  })
+
+  it('returns empty arrays for all collection fields on parse failure', () => {
+    const filePath = createTempFile('export const z = 3')
+
+    const spy = spyOn(extractImportsModule, 'extractImports').mockImplementation(() => {
+      throw new Error('Simulated failure')
+    })
+
+    let result: ReturnType<typeof parseFile>
+    try {
+      result = parseFile(filePath)
+    } finally {
+      spy.mockRestore()
+    }
+
+    expect(result!.imports).toEqual([])
+    expect(result!.localImports).toEqual([])
+    expect(result!.externalImports).toEqual([])
+    expect(result!.exports).toEqual([])
+    expect(result!.symbols).toEqual([])
+    expect(result!.hooks).toEqual([])
+    expect(result!.envVars).toEqual([])
+    expect(result!.apiCalls).toEqual([])
+    expect(result!.comments.todo).toEqual([])
+    expect(result!.comments.fixme).toEqual([])
+    expect(result!.comments.hack).toEqual([])
+    expect(result!.comments.invariant).toEqual([])
+    expect(result!.comments.decision).toEqual([])
+    expect(result!.hasSideEffects).toBe(false)
+  })
+
+  it('returns empty analysis when trying to parse a non-existent file path', () => {
+    const filePath = '/tmp/this-file-does-not-exist-braito-test.ts'
+
+    const result = parseFile(filePath)
+
+    expect(result).toBeDefined()
+    expect(result.filePath).toBe(filePath)
+    expect(result.imports).toEqual([])
+    expect(result.exports).toEqual([])
+  })
+
+  it('still parses valid TypeScript files correctly', () => {
+    const filePath = createTempFile(`
+      import { foo } from './foo'
+      export const bar = 42
+    `)
+
+    const result = parseFile(filePath)
+
+    expect(result.filePath).toBe(filePath)
+    expect(result.imports).toContain('./foo')
+    expect(result.exports).toContain('bar')
+  })
+})


### PR DESCRIPTION
## Summary

- Wrapped the entire body of `parseFile` in a try/catch block; on any error a `logger.warn` is emitted and an empty `StaticFileAnalysis` is returned so the rest of the pipeline continues uninterrupted
- Added `emptyAnalysis` helper (already existed for unknown extensions) reused in the catch path
- Added `logger` import from `../utils/logger.ts`

## Test plan

- [ ] Run `bun test tests/ast/parseFileResilience.test.ts` — all 5 tests should pass
- [ ] Verify warning messages are printed to stderr when an extractor throws
- [ ] Run `bun test` to confirm no regressions across the full test suite

https://claude.ai/code/session_01AGToc4kS7e8vmi41geuYxH