### PR TITLE
feat: TTY progress bar for generate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to braito will be documented here.
 ## [Unreleased]
 
 ### Added
+- **Progress indicator** — `ProgressBar` class in `src/core/utils/progress.ts` renders an in-place TTY progress bar (carriage return, filled/empty blocks, percentage, count) for both the analysis and note-writing phases of `generate`; output goes to stderr to keep stdout clean for `--format json` piping; non-TTY environments (CI) receive no output to avoid garbled logs; 6 tests added (`tests/utils/progress.test.ts`)
 - **LLM synthesis timeout** — `synthesizeFileNote` accepts a `timeoutMs` parameter (default 30 000 ms); `Promise.race` races the provider call against a timeout reject, falling back to the static note automatically via the existing catch block; configurable via `llm.timeoutMs` in `ai-notes.config.ts`; `LLMConfig` type and `llmConfigSchema` updated accordingly
 - **Config validation** — `loadConfig` now validates `ai-notes.config.ts` with a Zod schema (`src/core/config/configSchema.ts`); invalid values (unknown provider, out-of-range threshold/temperature, empty output dir, non-positive staleThresholdDays) emit a clear error with field paths instead of silently falling back to defaults; 15 tests added (`tests/config/configSchema.test.ts`)
 - **Temperature bug fix** — confirmed `provider/anthropic.ts` and `provider/openai.ts` correctly pass `request.temperature` through the `LLMRequest` type; marked resolved

--- a/TODO.md
+++ b/TODO.md
@@ -44,6 +44,8 @@ Tracked next steps for braito. Move items to CHANGELOG.md when completed.
 
 - [x] **Cycle detection in dependency graph** — detect and warn about circular imports during graph construction; flag involved files in their notes.
 
+- [x] **Progress indicator** — TTY progress bar for analyze and write-notes phases in the `generate` command; uses carriage return to update in place; suppressed in non-TTY (CI) environments.
+
 - [ ] **CLI e2e tests** — integration tests for `generate`, `watch`, `mcp`, and `ui` commands using real temp fixtures; currently only unit tests exist.
 
 - [x] **`scan --format json`** — add `--format json|table` flag to the `scan` command for machine-readable output and integration with external tools.

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -23,6 +23,7 @@ import { loadCache, saveCache } from '../../core/cache/cacheStore.ts'
 import { loadAnalysisStore, saveAnalysisStore } from '../../core/cache/analysisStore.ts'
 import { concurrentMap } from '../../core/utils/concurrentMap.ts'
 import { logger } from '../../core/utils/logger.ts'
+import { ProgressBar } from '../../core/utils/progress.ts'
 import type { AiFileNote } from '../../core/types/ai-note.ts'
 import type { NoteDiff } from '../../core/output/diffNotes.ts'
 import type { StaticFileAnalysis } from '../../core/types/file-analysis.ts'
@@ -58,6 +59,7 @@ export async function runGenerate(args: {
   const analyses: StaticFileAnalysis[] = []
   let analysisHits = 0
 
+  const analysisProgress = new ProgressBar(files.length, 'Analyzing')
   for (const file of files) {
     const hash = await computeHash(file.path)
     fileHashes.set(file.relativePath, hash)
@@ -76,6 +78,7 @@ export async function runGenerate(args: {
       analyses.push(analysis)
       analysisStore.set(file.relativePath, analysis)
     }
+    analysisProgress.tick(file.relativePath)
   }
 
   if (analysisHits > 0) logger.info(`Reused ${analysisHits} cached analyses (skipped ts-morph parse)`)
@@ -139,6 +142,7 @@ export async function runGenerate(args: {
 
   // Use concurrentMap so multiple files are processed in parallel up to `concurrency` limit.
   // Results may be null when a file is skipped (hash unchanged).
+  const progress = new ProgressBar(filteredAnalyses.length, 'Writing notes')
   const noteResults = await concurrentMap(
     filteredAnalyses,
     async (analysis): Promise<{ note: AiFileNote; relativePath: string; hash: string; diff?: NoteDiff } | null> => {
@@ -188,6 +192,8 @@ export async function runGenerate(args: {
       }
 
       const diff = (args.diff && oldNote) ? diffNotes(oldNote, note) : undefined
+
+      progress.tick(path.relative(root, analysis.filePath))
 
       await writeJsonNote(note, root, config.output)
       await writeMarkdownNote(note, root, config.output)

--- a/src/core/utils/progress.ts
+++ b/src/core/utils/progress.ts
@@ -1,0 +1,27 @@
+export class ProgressBar {
+  private total: number
+  private current = 0
+  private label: string
+  private isTTY: boolean
+
+  constructor(total: number, label = 'Processing') {
+    this.total = total
+    this.label = label
+    this.isTTY = process.stderr.isTTY ?? false
+  }
+
+  tick(description = ''): void {
+    this.current++
+    if (!this.isTTY) return  // non-TTY: print nothing (avoid garbled CI output)
+    const pct = Math.round((this.current / this.total) * 100)
+    const filled = Math.round(pct / 5)
+    const bar = '█'.repeat(filled) + '░'.repeat(20 - filled)
+    const line = `\r  ${this.label} [${bar}] ${pct}% (${this.current}/${this.total}) ${description.slice(0, 30)}`
+    process.stderr.write(line)
+    if (this.current === this.total) process.stderr.write('\n')
+  }
+
+  clear(): void {
+    if (this.isTTY) process.stderr.write('\r' + ' '.repeat(80) + '\r')
+  }
+}

--- a/tests/utils/progress.test.ts
+++ b/tests/utils/progress.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
+import { ProgressBar } from '../../src/core/utils/progress.ts'
+
+describe('ProgressBar', () => {
+  let stderrWrite: typeof process.stderr.write
+  let written: string[]
+
+  beforeEach(() => {
+    written = []
+    stderrWrite = process.stderr.write.bind(process.stderr)
+    process.stderr.write = ((chunk: string) => {
+      written.push(chunk)
+      return true
+    }) as typeof process.stderr.write
+  })
+
+  afterEach(() => {
+    process.stderr.write = stderrWrite
+  })
+
+  it('tick() increments current correctly', () => {
+    // Use isTTY true to observe the output
+    const originalIsTTY = process.stderr.isTTY
+    ;(process.stderr as { isTTY: boolean }).isTTY = true
+
+    const bar = new ProgressBar(5, 'Testing')
+    bar.tick('file1.ts')
+    bar.tick('file2.ts')
+
+    // Current should be 2 out of 5 → 40%
+    const lastLine = written[written.length - 1]
+    expect(lastLine).toContain('(2/5)')
+    expect(lastLine).toContain('40%')
+
+    ;(process.stderr as { isTTY: boolean }).isTTY = originalIsTTY
+  })
+
+  it('does not write to stderr when not TTY', () => {
+    const originalIsTTY = process.stderr.isTTY
+    ;(process.stderr as { isTTY: boolean }).isTTY = false
+
+    const bar = new ProgressBar(3, 'Silent')
+    bar.tick('a.ts')
+    bar.tick('b.ts')
+    bar.tick('c.ts')
+
+    expect(written).toHaveLength(0)
+
+    ;(process.stderr as { isTTY: boolean }).isTTY = originalIsTTY
+  })
+
+  it('writes a newline when the last item is ticked', () => {
+    const originalIsTTY = process.stderr.isTTY
+    ;(process.stderr as { isTTY: boolean }).isTTY = true
+
+    const bar = new ProgressBar(2, 'Finishing')
+    bar.tick('first.ts')
+    const beforeLast = written.length
+
+    bar.tick('last.ts')
+
+    // After the final tick there should be an extra newline write
+    expect(written.length).toBeGreaterThan(beforeLast)
+    const newlineWrite = written[written.length - 1]
+    expect(newlineWrite).toBe('\n')
+
+    ;(process.stderr as { isTTY: boolean }).isTTY = originalIsTTY
+  })
+
+  it('clear() does not throw when not TTY', () => {
+    const originalIsTTY = process.stderr.isTTY
+    ;(process.stderr as { isTTY: boolean }).isTTY = false
+
+    const bar = new ProgressBar(1)
+    expect(() => bar.clear()).not.toThrow()
+
+    ;(process.stderr as { isTTY: boolean }).isTTY = originalIsTTY
+  })
+
+  it('clear() does not throw when TTY', () => {
+    const originalIsTTY = process.stderr.isTTY
+    ;(process.stderr as { isTTY: boolean }).isTTY = true
+
+    const bar = new ProgressBar(1)
+    expect(() => bar.clear()).not.toThrow()
+
+    ;(process.stderr as { isTTY: boolean }).isTTY = originalIsTTY
+  })
+
+  it('100% progress bar shows all filled blocks', () => {
+    const originalIsTTY = process.stderr.isTTY
+    ;(process.stderr as { isTTY: boolean }).isTTY = true
+
+    const bar = new ProgressBar(1, 'Full')
+    bar.tick('done.ts')
+
+    const progressLine = written.find((w) => w.startsWith('\r'))
+    expect(progressLine).toBeDefined()
+    expect(progressLine).toContain('100%')
+    expect(progressLine).toContain('(1/1)')
+    // All 20 blocks should be filled
+    expect(progressLine).toContain('█'.repeat(20))
+
+    ;(process.stderr as { isTTY: boolean }).isTTY = originalIsTTY
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `ProgressBar` class (`src/core/utils/progress.ts`) with carriage-return in-place rendering using filled/empty block characters, percentage, and file count
- Integrates two progress bars into `generate.ts`: one for the analysis (parse) phase and one for the note-writing phase
- Progress output goes to `stderr` so `stdout` stays clean for `--format json` piping; non-TTY environments (CI) receive no output to avoid garbled logs

## Test plan

- [x] Run `bun test ./tests/utils/progress.test.ts` — all 6 tests pass
- [ ] Manual: run `bun src/cli/index.ts generate --root ./` in a terminal and verify the animated progress bars appear and finish with a newline
- [ ] Manual: pipe stdout to verify no progress output leaks (`bun src/cli/index.ts generate --root ./ 2>/dev/null | cat`)

https://claude.ai/code/session_01AGToc4kS7e8vmi41geuYxH