### PR TITLE
feat(graph): resolve Go module-local imports into graph edges

### DIFF
--- a/src/core/graph/buildDependencyGraph.ts
+++ b/src/core/graph/buildDependencyGraph.ts
@@ -1,7 +1,28 @@
+import path from 'node:path'
+import fs from 'node:fs'
 import type { StaticFileAnalysis } from '../types/file-analysis.ts'
 import { resolveImportPath } from './resolveImportPath.ts'
 
 type PathAliases = Record<string, string[]>
+
+/**
+ * Reads `<root>/go.mod` if present and returns the declared module path
+ * (e.g. "rd-autonomous-team"). Returns null when no go.mod exists at the
+ * root or when the file is malformed. Only the root-level go.mod is
+ * consulted; for monorepos with multiple modules, the analyzer's own
+ * per-file walker still catches them at the analysis layer.
+ */
+function readRootGoModulePath(root: string): string | null {
+  const goModPath = path.join(root, 'go.mod')
+  if (!fs.existsSync(goModPath)) return null
+  try {
+    const content = fs.readFileSync(goModPath, 'utf8')
+    const match = content.match(/^module\s+(\S+)/m)
+    return match ? match[1] : null
+  } catch {
+    return null
+  }
+}
 
 export function buildDependencyGraph(
   analyses: StaticFileAnalysis[],
@@ -9,9 +30,11 @@ export function buildDependencyGraph(
   aliases: PathAliases = {},
 ): Map<string, string[]> {
   const graph = new Map<string, string[]>()
+  const goModulePath = readRootGoModulePath(root)
+  const opts = { aliases, goModulePath: goModulePath ?? undefined }
 
   for (const analysis of analyses) {
-    graph.set(analysis.filePath, resolveFileDeps(analysis, root, aliases))
+    graph.set(analysis.filePath, resolveFileDeps(analysis, root, opts))
   }
 
   return graph
@@ -27,17 +50,19 @@ export function updateDependencyGraph(
   root: string,
   aliases: PathAliases = {},
 ): void {
-  graph.set(analysis.filePath, resolveFileDeps(analysis, root, aliases))
+  const goModulePath = readRootGoModulePath(root)
+  const opts = { aliases, goModulePath: goModulePath ?? undefined }
+  graph.set(analysis.filePath, resolveFileDeps(analysis, root, opts))
 }
 
 function resolveFileDeps(
   analysis: StaticFileAnalysis,
   root: string,
-  aliases: PathAliases,
+  opts: { aliases: PathAliases; goModulePath?: string },
 ): string[] {
   const deps: string[] = []
   for (const importSpecifier of analysis.localImports) {
-    const resolved = resolveImportPath(importSpecifier, analysis.filePath, root, aliases)
+    const resolved = resolveImportPath(importSpecifier, analysis.filePath, root, opts)
     if (resolved) deps.push(resolved)
   }
   return deps

--- a/src/core/graph/resolveImportPath.ts
+++ b/src/core/graph/resolveImportPath.ts
@@ -3,17 +3,54 @@ import fs from 'node:fs'
 
 type PathAliases = Record<string, string[]>
 
+/**
+ * Options bag for resolveImportPath. Kept as an optional final param so
+ * existing call sites that only pass aliases continue to work.
+ */
+export interface ResolveOptions {
+  aliases?: PathAliases
+  /**
+   * Go module path declared in `go.mod` (e.g. "rd-autonomous-team").
+   * When set, imports prefixed with `<goModulePath>/` are resolved as
+   * paths relative to the repo root. Required for module-local Go
+   * imports to produce graph edges.
+   */
+  goModulePath?: string
+}
+
 export function resolveImportPath(
   importSpecifier: string,
   fromFile: string,
   root: string,
-  aliases: PathAliases = {},
+  optsOrAliases: PathAliases | ResolveOptions = {},
 ): string | null {
+  // Backward-compatible signature: callers may pass aliases directly
+  // (legacy) or a full ResolveOptions bag (new). Normalize to opts.
+  const opts: ResolveOptions =
+    'aliases' in optsOrAliases || 'goModulePath' in optsOrAliases
+      ? (optsOrAliases as ResolveOptions)
+      : { aliases: optsOrAliases as PathAliases }
+  const aliases = opts.aliases ?? {}
+
   // Resolve relative imports
   if (importSpecifier.startsWith('.')) {
     const dir = path.dirname(fromFile)
     const resolved = path.resolve(dir, importSpecifier)
     return resolveWithExtensions(resolved)
+  }
+
+  // Resolve Go module-local imports (e.g. "rd-autonomous-team/internal/contracts")
+  // by stripping the module prefix and resolving relative to root.
+  if (opts.goModulePath) {
+    const prefix = opts.goModulePath + '/'
+    if (importSpecifier === opts.goModulePath || importSpecifier.startsWith(prefix)) {
+      const rest = importSpecifier === opts.goModulePath
+        ? ''
+        : importSpecifier.slice(prefix.length)
+      const candidate = path.resolve(root, rest)
+      const resolved = resolveWithExtensions(candidate)
+      if (resolved) return resolved
+    }
   }
 
   // Resolve alias imports (e.g. @/, ~/, or tsconfig paths)
@@ -33,21 +70,62 @@ export function resolveImportPath(
   return null
 }
 
-function resolveWithExtensions(base: string): string | null {
-  const extensions = ['.ts', '.tsx', '.js', '.jsx']
+// Extension priority: TS family first (most repos), then Go, then Python.
+// The order matters when multiple files with the same basename and
+// different extensions coexist — first match wins.
+const RESOLVE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.go', '.py']
 
+function resolveWithExtensions(base: string): string | null {
   if (fs.existsSync(base) && fs.statSync(base).isFile()) return base
 
-  for (const ext of extensions) {
+  for (const ext of RESOLVE_EXTENSIONS) {
     const candidate = base + ext
     if (fs.existsSync(candidate)) return candidate
   }
 
-  // Try index file
-  for (const ext of extensions) {
-    const candidate = path.join(base, `index${ext}`)
-    if (fs.existsSync(candidate)) return candidate
+  // Try directory index — for Go this maps a package import like
+  // `rd-autonomous-team/internal/contracts` to any *.go file in that
+  // directory (Go imports refer to packages, not individual files).
+  if (fs.existsSync(base) && fs.statSync(base).isDirectory()) {
+    // For Go: pick the first non-test .go file in the package directory.
+    // This is approximate (Go packages span multiple files) but produces
+    // a valid graph edge that tools like get_impact can act on.
+    const goFile = pickGoPackageFile(base)
+    if (goFile) return goFile
+
+    // For TS/JS: try index files
+    for (const ext of ['.ts', '.tsx', '.js', '.jsx']) {
+      const candidate = path.join(base, `index${ext}`)
+      if (fs.existsSync(candidate)) return candidate
+    }
+  } else {
+    // Try TS index file even if the bare base doesn't exist as a dir
+    // (covers `import './foo'` where ./foo/ exists but resolution
+    // started from a different working dir). Keep the original logic.
+    for (const ext of ['.ts', '.tsx', '.js', '.jsx']) {
+      const candidate = path.join(base, `index${ext}`)
+      if (fs.existsSync(candidate)) return candidate
+    }
   }
 
   return null
+}
+
+/**
+ * Returns the path to the first non-test .go file in a directory, or null.
+ * Used to map Go package imports (which target a directory) to a single
+ * file representative for graph edges.
+ */
+function pickGoPackageFile(dir: string): string | null {
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(dir)
+  } catch {
+    return null
+  }
+  // Prefer non-test files; fall back to anything if only tests exist.
+  const goFiles = entries.filter((f) => f.endsWith('.go'))
+  const nonTest = goFiles.filter((f) => !f.endsWith('_test.go'))
+  const pick = nonTest[0] ?? goFiles[0]
+  return pick ? path.join(dir, pick) : null
 }

--- a/tests/graph/buildDependencyGraph.go.test.ts
+++ b/tests/graph/buildDependencyGraph.go.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import path from 'node:path'
+import fs from 'node:fs'
+import os from 'node:os'
+import { buildDependencyGraph } from '../../src/core/graph/buildDependencyGraph.ts'
+import { resolveImportPath } from '../../src/core/graph/resolveImportPath.ts'
+import type { StaticFileAnalysis } from '../../src/core/types/file-analysis.ts'
+
+let tmpDir: string
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'braito-go-graph-test-'))
+  // Mimic a Go monorepo:
+  //   /go.mod  →  module rd-autonomous-team
+  //   /internal/agents/ralph_engine.go
+  //   /internal/contracts/types.go
+  //   /internal/llm/provider.go
+  fs.writeFileSync(path.join(tmpDir, 'go.mod'), 'module rd-autonomous-team\n\ngo 1.24\n')
+  fs.mkdirSync(path.join(tmpDir, 'internal', 'agents'), { recursive: true })
+  fs.mkdirSync(path.join(tmpDir, 'internal', 'contracts'), { recursive: true })
+  fs.mkdirSync(path.join(tmpDir, 'internal', 'llm'), { recursive: true })
+  fs.writeFileSync(path.join(tmpDir, 'internal', 'agents', 'ralph_engine.go'), 'package agents\n')
+  fs.writeFileSync(path.join(tmpDir, 'internal', 'contracts', 'types.go'), 'package contracts\n')
+  fs.writeFileSync(path.join(tmpDir, 'internal', 'llm', 'provider.go'), 'package llm\n')
+})
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function makeAnalysis(filePath: string, localImports: string[]): StaticFileAnalysis {
+  return {
+    filePath,
+    imports: localImports,
+    localImports,
+    externalImports: [],
+    exports: [],
+    exportDetails: [],
+    symbols: [],
+    hooks: [],
+    envVars: [],
+    apiCalls: [],
+    comments: { todo: [], fixme: [], hack: [], invariant: [], decision: [] },
+    hasSideEffects: false,
+    signatures: [],
+  }
+}
+
+describe('Go module-local imports', () => {
+  it('resolves <module>/path/to/pkg to a representative .go file', () => {
+    const ralphPath = path.join(tmpDir, 'internal', 'agents', 'ralph_engine.go')
+    const contractsImport = 'rd-autonomous-team/internal/contracts'
+    const llmImport = 'rd-autonomous-team/internal/llm'
+
+    const analyses = [
+      makeAnalysis(ralphPath, [contractsImport, llmImport]),
+    ]
+
+    const graph = buildDependencyGraph(analyses, tmpDir)
+    const deps = graph.get(ralphPath) ?? []
+
+    // Each module-local import should resolve to ONE .go file in the
+    // referenced package directory (the first non-test file we find).
+    expect(deps).toHaveLength(2)
+    expect(deps).toContain(path.join(tmpDir, 'internal', 'contracts', 'types.go'))
+    expect(deps).toContain(path.join(tmpDir, 'internal', 'llm', 'provider.go'))
+  })
+
+  it('falls back to null for imports outside the module path', () => {
+    // Stdlib + third-party imports never resolve via the module path —
+    // they remain external (no graph edge).
+    const ralphPath = path.join(tmpDir, 'internal', 'agents', 'ralph_engine.go')
+    const stdlibImport = 'context'
+
+    // Note: `localImports` from the analyzer would not include stdlib in
+    // the first place; we test resolveImportPath directly to assert the
+    // contract.
+    const resolved = resolveImportPath(stdlibImport, ralphPath, tmpDir, {
+      goModulePath: 'rd-autonomous-team',
+    })
+    expect(resolved).toBeNull()
+  })
+
+  it('skips Go module resolution when no goModulePath is provided', () => {
+    const ralphPath = path.join(tmpDir, 'internal', 'agents', 'ralph_engine.go')
+    const resolved = resolveImportPath(
+      'rd-autonomous-team/internal/contracts',
+      ralphPath,
+      tmpDir,
+      {}, // no goModulePath
+    )
+    expect(resolved).toBeNull()
+  })
+
+  it('handles bare-module import (specifier === module path)', () => {
+    const ralphPath = path.join(tmpDir, 'internal', 'agents', 'ralph_engine.go')
+    // Some Go code imports the bare module path (e.g. for cmd entry points).
+    // We resolve to root — there's typically no .go directly there in
+    // monorepos, so this returns null in our fixture (root has only
+    // go.mod). The important contract: it doesn't crash.
+    const resolved = resolveImportPath('rd-autonomous-team', ralphPath, tmpDir, {
+      goModulePath: 'rd-autonomous-team',
+    })
+    expect(resolved).toBeNull()
+  })
+})
+
+describe('resolveImportPath backward compatibility', () => {
+  it('still accepts a bare aliases object as the 4th param', () => {
+    // Older callers in the codebase pass `aliases` directly. We must
+    // not break that signature.
+    const aPath = path.join(tmpDir, 'a.ts')
+    fs.writeFileSync(aPath, '')
+    const resolved = resolveImportPath('./a', aPath, tmpDir, {})
+    // No aliases configured + no extension match because base is the
+    // file itself; resolveWithExtensions handles that.
+    expect(resolved).toBe(aPath)
+  })
+})


### PR DESCRIPTION
## Problem

The Go analyzer correctly extracts module-local imports (e.g. `rd-autonomous-team/internal/contracts`) into `analysis.localImports`, but `resolveImportPath` doesn't know how to map them to actual files on disk — it only handles relative imports and tsconfig path aliases.

The result: a dependency graph with **zero edges** for any Go monorepo. This silently breaks:
- `get_impact` — returns empty for any Go file
- `criticalityScore` — flat at baseline because consumer count is always 0
- Any downstream that relies on the graph

Discovered while smoke-testing against a Go monorepo (15 .go files in `internal/agents/`). Before:
```
Graph: 15 nodes, 0 edges
internal/agents/ralph_engine.go: deps=0, consumers=0
```

## Solution

1. `buildDependencyGraph` reads `<root>/go.mod` once at the start and extracts the declared module path.
2. `resolveImportPath` accepts an optional `goModulePath`. When set, imports prefixed with `<goModulePath>/` are stripped and resolved relative to root. Backward compatible — the legacy `aliases`-as-4th-arg signature still works.
3. `resolveWithExtensions` now tries `.go` and `.py`. For Go package imports (which target a directory), `pickGoPackageFile` picks the first non-test `.go` file as a representative for the graph edge.

## After the fix

Same monorepo:
```
Graph: 20 nodes, 25 edges
internal/agents/architect_engine.go: deps=3, consumers=1
```

`get_impact("internal/agents/architect_engine.go")` now correctly returns its dependent:
```json
{
  "totalAffected": 1,
  "dependents": [{ "path": "internal/agents/toolloop/engine.go", "level": 1 }]
}
```

## Tests

5 new tests in `tests/graph/buildDependencyGraph.go.test.ts`:
- Module-local import → `.go` file in package directory
- Stdlib import → null (no edge)
- Missing `goModulePath` → null (legacy behaviour preserved)
- Bare module-path import → doesn't crash
- Backward compat: aliases-as-4th-arg still accepted

Total: 10 → 15 graph tests, all green.

## Design notes / known limitations

- For Go package imports (which target a directory containing multiple `.go` files), we pick a single representative file per directory. Approximate but produces valid graph edges. A more thorough fix (multi-file edges or "package node" abstraction) is deferred.
- `go.work` multi-module workspaces NOT covered. Repos with multiple `go.mod` files at different levels won't see all module paths resolved.
- The `ResolveOptions` interface is the new canonical 4th-arg signature. The old `aliases` direct-pass is preserved indefinitely for stability.